### PR TITLE
docs(manipulation): full development docs + 2026 page + mermaid lightbox

### DIFF
--- a/docs/Areas/Manipulation.md
+++ b/docs/Areas/Manipulation.md
@@ -1,5 +1,31 @@
 # Manipulation
 
-Dynamic manipulation systems are crucial for advancing robotics because they allow robots to interact with their environments in ways that go far beyond pre-programmed actions. This capability is  particularly important for service robotics, where robots must navigate unstructured and unpredictable environments. Dynamic manipulation helps robots sense changes, modify trajectories, and grasp objects with variations in shape, size, and material. This opens the door to more complex tasks, from assisting with meal preparation to handling delicate objects in healthcare settings. The ability to adapt in real-time also promotes safe and seamless human-robot collaboration.
+Dynamic manipulation is what lets a service robot **interact** with an unstructured world. Instead of executing pre-programmed actions, FRIDA must sense changes in its environment, plan its trajectories, and grasp objects whose shape, size, and material vary from one trial to the next. Robust manipulation opens the door to tasks like meal preparation, item delivery, opening containers, and handing objects to people — all under live human-robot collaboration.
 
-Our physical implementation consists of a 6-DOF Xarm6 robotic arm utilizing MoveIt for trajectory planning. We developed custom picking and placing functionalities, incorporating additional libraries and algorithms, and leveraging feedback from a Zed2 stereo camera.
+Our pick & place pipeline is built around a **6-DOF UFactory xArm 6** with a custom 2-finger gripper, perceived by a **ZED 2** stereo camera, and planned through **MoveIt 2**.
+
+## Pipeline at a glance
+
+1. **2D Detection** — the Vision area classifies and locates objects in the RGB stream.
+2. **3D Perception** — the detection is fused with the ZED point cloud; we segment the supporting plane (RANSAC) and extract the target object cluster (Euclidean clustering on PCL).
+3. **Collision Scene** — the plane becomes a collision box and the object becomes a set of spheres or a reconstructed mesh, all pushed to the MoveIt planning scene.
+4. **Grasp Generation** — the **GPD** library scores candidate grasps on the object cluster. For thin objects (cutlery), a top-down PCA-aligned pose is computed directly.
+5. **Motion Planning** — MoveIt 2 plans a collision-free trajectory using **RRTConnect**, with the **IKFast** analytical IK solver.
+6. **Execution** — the trajectory is sent to the xArm driver; the gripper closes; a force-guarded descent variant exists for cutlery to avoid table impact.
+7. **Placement** — a Gaussian heatmap on the table cloud chooses the best free spot, with optional directional constraints ("close to", "left of", …).
+
+## Architecture
+
+The Manipulation area exposes a single ROS 2 action — `ManipulationAction` — that every task manager calls. A central `manipulation_core` node orchestrates specialized **Managers** (`PickManager`, `PlaceManager`, `PourManager`) which coordinate detection, perception, grasp generation, and motion in sequence. All motion is funnelled through a `motion_planning_server` that wraps MoveIt 2 and the xArm driver.
+
+## Highlights
+
+- **Dual-heatmap placing** — Gaussian heat kernel over free space combined with a Gaussian cool kernel over obstacles. Supports directional placements (`close_to`, `front`, `back`, `left`, `right`) and a forced-pose mode.
+- **Pouring** — orientation-aware path planning above the container centroid; supports an *already-grasped* mode to chain pick → pour → place without re-picking.
+- **Cutlery picks** — top-down PCA-aligned grasp pose with a force-guarded descent (xArm mode 5, joint-effort threshold) so the gripper stops on table contact.
+- **Custom gripper** — parallel rack-and-pinion mechanism with fractal silicone fingers, payload up to 1 kg. Grasp feedback exposed on `/gripper/grasp_state`.
+
+## Read more
+
+- For day-to-day engineering, see the **[Manipulation development documentation](../development/manipulation/overview.md)** — setup, architecture, packages, running tasks, and interfaces.
+- For historical context, browse the year-by-year **[advances over the years](../years/2026/Manipulation/index.md)**.

--- a/docs/assets/javascripts/mermaid-init.js
+++ b/docs/assets/javascripts/mermaid-init.js
@@ -45,20 +45,35 @@
     var scale = 1, tx = 0, ty = 0;
     var dragging = false, lastX = 0, lastY = 0;
 
+    // RAF-throttle transform writes. We mutate scale/tx/ty freely but
+    // only flush to the DOM once per animation frame. This keeps wheel
+    // and mousemove handlers from triggering 60+ style recalcs per second.
+    var transformPending = false;
     function applyTransform() {
-      if (currentMoved) {
-        currentMoved.style.transform =
-          "translate(" + tx + "px," + ty + "px) scale(" + scale + ")";
-      }
+      if (transformPending) return;
+      transformPending = true;
+      requestAnimationFrame(function () {
+        transformPending = false;
+        if (currentMoved) {
+          // translate3d() forces a GPU compositor layer — much cheaper
+          // for repeated transform updates than the 2D translate() form.
+          currentMoved.style.transform =
+            "translate3d(" + tx + "px," + ty + "px,0) scale(" + scale + ")";
+        }
+      });
     }
     function close() {
       overlay.classList.remove("rb-lb-open");
-      // Move the diagram back to its original spot.
+      // Move the diagram back and clear ALL inline styles we applied
+      // (including will-change, so the browser releases the GPU layer).
       if (currentMoved && currentPlaceholder) {
         currentMoved.style.transform = "";
         currentMoved.style.maxWidth = "";
         currentMoved.style.maxHeight = "";
         currentMoved.style.cursor = "";
+        currentMoved.style.willChange = "";
+        currentMoved.style.transformOrigin = "";
+        currentMoved.style.display = "";
         currentPlaceholder.parentNode.replaceChild(currentMoved, currentPlaceholder);
       }
       currentMoved = null;
@@ -128,10 +143,14 @@
     mermaidDiv.parentNode.replaceChild(ph, mermaidDiv);
 
     // Style the diagram for the lightbox: it keeps its intrinsic size,
-    // but we apply a transform: scale() that fills the stage.
+    // but we apply a transform that scales/translates inside the stage.
+    // willChange + an initial translate3d() prime the GPU compositor
+    // layer so the first wheel event isn't slow from layer promotion.
     mermaidDiv.style.cursor = "grab";
     mermaidDiv.style.transformOrigin = "center center";
     mermaidDiv.style.display = "block";
+    mermaidDiv.style.willChange = "transform";
+    mermaidDiv.style.transform = "translate3d(0,0,0) scale(1)";
     stage.appendChild(mermaidDiv);
     currentMoved = mermaidDiv;
     currentPlaceholder = ph;

--- a/docs/assets/javascripts/mermaid-init.js
+++ b/docs/assets/javascripts/mermaid-init.js
@@ -46,8 +46,7 @@
     var dragging = false, lastX = 0, lastY = 0;
 
     // RAF-throttle transform writes. We mutate scale/tx/ty freely but
-    // only flush to the DOM once per animation frame. This keeps wheel
-    // and mousemove handlers from triggering 60+ style recalcs per second.
+    // only flush to the DOM once per animation frame.
     var transformPending = false;
     function applyTransform() {
       if (transformPending) return;
@@ -55,12 +54,29 @@
       requestAnimationFrame(function () {
         transformPending = false;
         if (currentMoved) {
-          // translate3d() forces a GPU compositor layer — much cheaper
-          // for repeated transform updates than the 2D translate() form.
           currentMoved.style.transform =
             "translate3d(" + tx + "px," + ty + "px,0) scale(" + scale + ")";
         }
       });
+    }
+
+    // Crisp-vs-fast trade-off:
+    //   * With `will-change: transform` the browser pre-rasterizes the
+    //     element at its natural size and lets the GPU composite scale
+    //     it. Fast but blurry at high scale (bilinear filtering).
+    //   * Without it, the browser re-rasterizes the SVG on every transform
+    //     change. Crisp (SVG is vector) but slow on rapid input.
+    // We get both by toggling: enable it while the user is interacting
+    // (wheel/drag) and remove it after a short idle so the browser
+    // re-rasterizes the diagram at the final scale — crisp result.
+    var crispTimer = null;
+    function bumpInteractive() {
+      if (!currentMoved) return;
+      currentMoved.style.willChange = "transform";
+      clearTimeout(crispTimer);
+      crispTimer = setTimeout(function () {
+        if (currentMoved) currentMoved.style.willChange = "";
+      }, 180);
     }
     function close() {
       overlay.classList.remove("rb-lb-open");
@@ -98,6 +114,7 @@
       // → zoom IN. Scroll DOWN → zoom OUT.
       var factor = Math.exp(-e.deltaY * 0.0025);
       scale = Math.min(20, Math.max(0.1, scale * factor));
+      bumpInteractive();
       applyTransform();
     }, { passive: false });
     overlay.addEventListener("mousedown", function (e) {
@@ -106,6 +123,7 @@
       dragging = true;
       lastX = e.clientX; lastY = e.clientY;
       stage.style.cursor = "grabbing";
+      bumpInteractive();
       e.preventDefault();
     });
     document.addEventListener("mousemove", function (e) {
@@ -113,6 +131,7 @@
       tx += e.clientX - lastX;
       ty += e.clientY - lastY;
       lastX = e.clientX; lastY = e.clientY;
+      bumpInteractive();
       applyTransform();
     });
     document.addEventListener("mouseup", function () {
@@ -143,14 +162,15 @@
     mermaidDiv.parentNode.replaceChild(ph, mermaidDiv);
 
     // Style the diagram for the lightbox: it keeps its intrinsic size,
-    // but we apply a transform that scales/translates inside the stage.
-    // willChange + an initial translate3d() prime the GPU compositor
-    // layer so the first wheel event isn't slow from layer promotion.
+    // and we apply a transform that scales/translates inside the stage.
+    // No `will-change: transform` here — that would force the browser
+    // to pre-rasterize at natural size and bilinear-scale to the target
+    // (blur). bumpInteractive() turns it on only during wheel/drag and
+    // releases it after 180ms idle so the SVG re-rasterizes crisp at
+    // the final scale.
     mermaidDiv.style.cursor = "grab";
     mermaidDiv.style.transformOrigin = "center center";
     mermaidDiv.style.display = "block";
-    mermaidDiv.style.willChange = "transform";
-    mermaidDiv.style.transform = "translate3d(0,0,0) scale(1)";
     stage.appendChild(mermaidDiv);
     currentMoved = mermaidDiv;
     currentPlaceholder = ph;

--- a/docs/assets/javascripts/mermaid-init.js
+++ b/docs/assets/javascripts/mermaid-init.js
@@ -1,0 +1,265 @@
+// Mermaid badge + lightbox.
+//
+// THE TRICK: mkdocs-material puts the rendered Mermaid SVG inside a
+// CLOSED shadow root attached to a <div class="mermaid">. From regular
+// JS we cannot enumerate the shadow's contents — `element.shadowRoot`
+// returns null, `querySelector('svg')` returns null. The diagram is only
+// visible to the user because the browser renders shadow DOM natively.
+//
+// Implications:
+//   * We cannot clone the SVG.
+//   * We CAN move the .mermaid div around — the shadow comes with it.
+//   * We CAN apply CSS transforms to the div — they cascade visually.
+//
+// Strategy:
+//   1. Watch for <div class="mermaid"> elements that have non-zero size
+//      (= shadow root populated = render finished).
+//   2. Attach the "Enlarge" badge as a sibling absolute element so it
+//      doesn't pollute the .mermaid div's contents (which Material may
+//      manage).
+//   3. On click, MOVE the .mermaid div into the lightbox stage and leave
+//      a placeholder behind so we can restore it on close.
+//   4. Wheel/drag apply CSS transforms to the moved div.
+
+(function () {
+  var LOG = "[rb-mermaid]";
+  var BADGE_CLS = "rb-zoom-badge";
+  var PLACEHOLDER_CLS = "rb-mermaid-placeholder";
+  var WRAP_CLS = "rb-mermaid-wrap";
+
+  // ---------- Lightbox (one global instance) ----------
+  var currentMoved = null;   // the mermaid div currently shown in the lightbox
+  var currentPlaceholder = null;  // its placeholder back in the article
+
+  function buildLightbox() {
+    if (document.getElementById("rb-mermaid-lightbox")) return;
+    var overlay = document.createElement("div");
+    overlay.id = "rb-mermaid-lightbox";
+    overlay.innerHTML =
+      '<button class="rb-lb-close" type="button" aria-label="Close (Esc)">&times;</button>' +
+      '<div class="rb-lb-stage"></div>' +
+      '<div class="rb-lb-hint">Scroll to zoom · drag to pan · Esc to close</div>';
+    document.body.appendChild(overlay);
+
+    var stage = overlay.querySelector(".rb-lb-stage");
+    var scale = 1, tx = 0, ty = 0;
+    var dragging = false, lastX = 0, lastY = 0;
+
+    function applyTransform() {
+      if (currentMoved) {
+        currentMoved.style.transform =
+          "translate(" + tx + "px," + ty + "px) scale(" + scale + ")";
+      }
+    }
+    function close() {
+      overlay.classList.remove("rb-lb-open");
+      // Move the diagram back to its original spot.
+      if (currentMoved && currentPlaceholder) {
+        currentMoved.style.transform = "";
+        currentMoved.style.maxWidth = "";
+        currentMoved.style.maxHeight = "";
+        currentMoved.style.cursor = "";
+        currentPlaceholder.parentNode.replaceChild(currentMoved, currentPlaceholder);
+      }
+      currentMoved = null;
+      currentPlaceholder = null;
+      document.body.style.overflow = "";
+      scale = 1; tx = 0; ty = 0;
+    }
+
+    overlay.addEventListener("click", function (e) {
+      // Click on overlay background (not on the diagram or close btn) closes.
+      if (e.target === overlay || e.target.classList.contains("rb-lb-close")) close();
+    });
+    document.addEventListener("keydown", function (e) {
+      if (e.key === "Escape" && overlay.classList.contains("rb-lb-open")) close();
+    });
+    overlay.addEventListener("wheel", function (e) {
+      if (!overlay.classList.contains("rb-lb-open")) return;
+      e.preventDefault();
+      // Exponential zoom: proportional to deltaY magnitude.  Works
+      // naturally for both wheel mice (deltaY ≈ ±100) and trackpads
+      // (smaller, continuous deltaY).  Scroll UP shrinks deltaY → e^pos
+      // → zoom IN. Scroll DOWN → zoom OUT.
+      var factor = Math.exp(-e.deltaY * 0.0025);
+      scale = Math.min(20, Math.max(0.1, scale * factor));
+      applyTransform();
+    }, { passive: false });
+    overlay.addEventListener("mousedown", function (e) {
+      if (!overlay.classList.contains("rb-lb-open")) return;
+      if (e.target.closest(".rb-lb-close")) return;
+      dragging = true;
+      lastX = e.clientX; lastY = e.clientY;
+      stage.style.cursor = "grabbing";
+      e.preventDefault();
+    });
+    document.addEventListener("mousemove", function (e) {
+      if (!dragging) return;
+      tx += e.clientX - lastX;
+      ty += e.clientY - lastY;
+      lastX = e.clientX; lastY = e.clientY;
+      applyTransform();
+    });
+    document.addEventListener("mouseup", function () {
+      dragging = false;
+      stage.style.cursor = "grab";
+    });
+
+    overlay.__reset = function (initial) {
+      scale = (typeof initial === "number" && isFinite(initial)) ? initial : 1;
+      tx = 0; ty = 0;
+      applyTransform();
+    };
+  }
+
+  function openLightboxWith(mermaidDiv) {
+    if (currentMoved) return; // already open
+    buildLightbox();
+    var overlay = document.getElementById("rb-mermaid-lightbox");
+    var stage = overlay.querySelector(".rb-lb-stage");
+
+    // Capture the diagram's article-size and create a same-size
+    // placeholder so the layout doesn't jump while it's in the lightbox.
+    var rect = mermaidDiv.getBoundingClientRect();
+    var ph = document.createElement("div");
+    ph.className = PLACEHOLDER_CLS;
+    ph.style.width = rect.width + "px";
+    ph.style.height = rect.height + "px";
+    mermaidDiv.parentNode.replaceChild(ph, mermaidDiv);
+
+    // Style the diagram for the lightbox: it keeps its intrinsic size,
+    // but we apply a transform: scale() that fills the stage.
+    mermaidDiv.style.cursor = "grab";
+    mermaidDiv.style.transformOrigin = "center center";
+    mermaidDiv.style.display = "block";
+    stage.appendChild(mermaidDiv);
+    currentMoved = mermaidDiv;
+    currentPlaceholder = ph;
+
+    overlay.classList.add("rb-lb-open");
+    document.body.style.overflow = "hidden";
+
+    // Compute the fit scale on the NEXT frame, after the browser has
+    // laid out the moved diagram inside the lightbox stage (its
+    // intrinsic size can differ from the article-context size).
+    requestAnimationFrame(function () {
+      var sw = stage.clientWidth || window.innerWidth * 0.95;
+      var sh = stage.clientHeight || window.innerHeight * 0.9;
+      var dw = mermaidDiv.clientWidth || rect.width || 1;
+      var dh = mermaidDiv.clientHeight || rect.height || 1;
+      // Start at ~75% of the available stage so the user has ample room
+      // to zoom in further with the wheel.
+      var fitScale = Math.min(sw / dw, sh / dh) * 0.75;
+      fitScale = Math.max(1, Math.min(5, fitScale));
+      overlay.__reset(fitScale);
+      console.log(LOG, "lightbox: stage=" + sw + "x" + sh +
+        " diagram=" + dw + "x" + dh + " fitScale=" + fitScale.toFixed(2));
+    });
+  }
+
+  // ---------- Badge attachment ----------
+  // Each mermaid div gets a sibling wrapper that contains both the div
+  // and the badge. The badge does NOT live inside the .mermaid div — so
+  // it never enters Material's content extraction.
+  //
+  // We only wrap once Material has rendered (the .mermaid div has size).
+  function maybeWrap(el) {
+    if (el.__rbBadged) return;
+    // Render done? Material attaches a closed shadow DOM that gives the
+    // div real layout dimensions. An empty div has clientHeight 0.
+    if (!el.clientHeight && !el.clientWidth) return;
+    el.__rbBadged = true;
+
+    var parent = el.parentNode;
+    if (!parent) return;
+
+    var wrap = document.createElement("div");
+    wrap.className = WRAP_CLS;
+    parent.insertBefore(wrap, el);
+    wrap.appendChild(el);
+
+    var badge = document.createElement("button");
+    badge.className = BADGE_CLS;
+    badge.type = "button";
+    badge.innerHTML = "&#x2922; Enlarge";
+    badge.title = "Open at full size";
+    badge.addEventListener("click", function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      try { openLightboxWith(el); }
+      catch (err) { console.error(LOG, "openLightboxWith threw:", err); }
+    });
+    wrap.appendChild(badge);
+
+    // Clicking the diagram itself also opens.
+    wrap.addEventListener("click", function (e) {
+      if (e.target.closest("." + BADGE_CLS)) return;
+      try { openLightboxWith(el); }
+      catch (err) { console.error(LOG, "openLightboxWith threw:", err); }
+    });
+
+    console.log(LOG, "badge wrap attached for", el);
+  }
+
+  var MERMAID_SEL = "div.mermaid";
+
+  function scan() {
+    buildLightbox();
+    document.querySelectorAll(MERMAID_SEL).forEach(maybeWrap);
+  }
+
+  // ---------- Observe the DOM ----------
+  // Material creates a NEW <div class="mermaid"> via `e.replaceWith(r)`
+  // — that fires a childList mutation on the parent. We catch it and
+  // wait for the div to have a real size (shadow populated).
+  var outer = new MutationObserver(function (mutations) {
+    var sawMermaid = false;
+    for (var i = 0; i < mutations.length && !sawMermaid; i++) {
+      var m = mutations[i];
+      if (m.addedNodes && m.addedNodes.length) {
+        for (var j = 0; j < m.addedNodes.length; j++) {
+          var n = m.addedNodes[j];
+          if (n.nodeType !== 1) continue;
+          if ((n.matches && n.matches(MERMAID_SEL)) ||
+              (n.querySelector && n.querySelector(MERMAID_SEL))) {
+            sawMermaid = true; break;
+          }
+        }
+      }
+    }
+    if (sawMermaid) {
+      // Wait a tick for the shadow root to populate, then try to wrap.
+      scan();
+      setTimeout(scan, 50);
+      setTimeout(scan, 250);
+    }
+  });
+
+  function bootstrap() {
+    buildLightbox();
+    scan();
+    outer.observe(document.body || document.documentElement, {
+      childList: true, subtree: true,
+    });
+    if (typeof window.document$ !== "undefined" && typeof window.document$.subscribe === "function") {
+      window.document$.subscribe(function () {
+        [50, 250, 1000, 3000].forEach(function (t) { setTimeout(scan, t); });
+      });
+    }
+    // Also poll once a second for the first 10s to catch the moment
+    // Material's mermaid render finishes (closed shadow attachment
+    // doesn't always fire a useful mutation).
+    var ticks = 0;
+    var poll = setInterval(function () {
+      scan();
+      ticks++;
+      if (ticks > 10) clearInterval(poll);
+    }, 1000);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", bootstrap);
+  } else {
+    bootstrap();
+  }
+})();

--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -528,8 +528,9 @@ button:focus,
 #rb-mermaid-lightbox {
   position: fixed;
   inset: 0;
-  background: rgba(11, 22, 48, 0.92);
-  backdrop-filter: blur(6px);
+  /* Solid backdrop (more opaque) instead of backdrop-filter: blur(...) —
+     blur compositor work hurts wheel-zoom framerate significantly. */
+  background: rgba(7, 16, 35, 0.96);
   z-index: 99999;
   display: none;
   align-items: center;
@@ -537,6 +538,8 @@ button:focus,
   padding: 32px 48px 56px;
   box-sizing: border-box;
   opacity: 1;
+  /* Isolate from the rest of the page to skip layout/paint propagation. */
+  contain: layout style paint;
 }
 
 #rb-mermaid-lightbox.rb-lb-open {
@@ -565,15 +568,22 @@ button:focus,
   box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
 }
 
-/* The cloned content (SVG or div). max-width / max-height keep it
-   within the modal; transform-origin so wheel-zoom centers correctly. */
+/* The moved diagram (or any other content placed in the stage).
+   - max-width / max-height keep it inside the modal.
+   - transform-origin: center so wheel zoom centers correctly.
+   - NO CSS transition — wheel events already drive the transform from
+     JS at full RAF rate; layering a 0.08s ease on top causes the
+     compositor to interpolate every frame, killing zoom responsiveness.
+   - will-change + translateZ promote the element to its own GPU layer
+     so scale/translate operations bypass the main-thread paint cycle. */
 #rb-mermaid-lightbox .rb-lb-stage > * {
   max-width: 100%;
   max-height: 100%;
   width: auto;
   height: auto;
   transform-origin: center center;
-  transition: transform 0.08s ease-out;
+  transition: none;
+  will-change: transform;
   pointer-events: auto;
 }
 

--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -571,11 +571,11 @@ button:focus,
 /* The moved diagram (or any other content placed in the stage).
    - max-width / max-height keep it inside the modal.
    - transform-origin: center so wheel zoom centers correctly.
-   - NO CSS transition — wheel events already drive the transform from
-     JS at full RAF rate; layering a 0.08s ease on top causes the
-     compositor to interpolate every frame, killing zoom responsiveness.
-   - will-change + translateZ promote the element to its own GPU layer
-     so scale/translate operations bypass the main-thread paint cycle. */
+   - NO CSS transition — JS already drives transform writes at RAF rate.
+   - NO `will-change: transform` here. JS toggles it on for the duration
+     of interaction (wheel/drag) and removes it after idle so the SVG
+     re-rasterizes crisp at the final scale (bilinear filtering on a
+     pre-rasterized GPU layer is what was causing the blur). */
 #rb-mermaid-lightbox .rb-lb-stage > * {
   max-width: 100%;
   max-height: 100%;
@@ -583,7 +583,6 @@ button:focus,
   height: auto;
   transform-origin: center center;
   transition: none;
-  will-change: transform;
   pointer-events: auto;
 }
 

--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -424,3 +424,212 @@ button:focus,
     display: none;
   }
 }
+/* =====================================================================
+   Mermaid diagrams — larger by default, click-to-zoom, breakout width
+   ===================================================================== */
+
+/* Container Material emits for fenced mermaid blocks.
+   - Center the SVG horizontally
+   - Allow horizontal scroll if the diagram exceeds the column width
+   - Give it a soft frame so it doesn't look like raw text
+*/
+.md-typeset pre.mermaid,
+.md-typeset .mermaid {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #ffffff;
+  border: 1px solid rgba(2, 6, 23, 0.08);
+  border-radius: 10px;
+  padding: 18px 12px;
+  margin: 18px 0 24px;
+  box-shadow: 0 6px 20px rgba(2, 6, 23, 0.05);
+  overflow-x: auto;
+  transition: box-shadow 0.18s ease, transform 0.18s ease;
+}
+
+.md-typeset pre.mermaid:hover,
+.md-typeset .mermaid:hover {
+  box-shadow: 0 10px 28px rgba(2, 6, 23, 0.10);
+}
+
+/* The mermaid container holds the SVG. Make the rendered SVG fill the
+   container width — never exceed it, never push into the sidebar/TOC.
+   Complex diagrams that would overflow trigger horizontal scroll inside
+   the container, and clicking opens the diagram at full size in a new
+   tab (see mermaid-init.js). */
+.md-typeset pre.mermaid svg,
+.md-typeset .mermaid svg {
+  width: 100%;
+  height: auto;
+  max-width: 100%;
+}
+
+/* While Mermaid is fetching/parsing, the <pre> shows raw source. Hide it
+   so users don't see the source flash before the SVG renders. */
+.md-typeset pre.mermaid:not([data-processed="true"]) code {
+  color: transparent;
+  user-select: none;
+}
+
+/* =====================================================================
+   Mermaid lightbox — click any diagram to open it at full screen size
+   ===================================================================== */
+
+/* Wrapper containing the mermaid div AND the badge. Sibling-based so
+   the badge is never inside .mermaid (Material would extract its text
+   as source code and break the render). */
+.md-typeset .rb-mermaid-wrap {
+  position: relative;
+  margin: 18px 0 24px;
+  cursor: zoom-in;
+}
+
+/* Placeholder kept while the diagram is moved into the lightbox, so
+   article layout doesn't reflow. */
+.md-typeset .rb-mermaid-placeholder {
+  background: linear-gradient(180deg, #f4f6fb, #ffffff);
+  border: 1px dashed rgba(2, 6, 23, 0.15);
+  border-radius: 10px;
+}
+
+/* Top-right corner badge — bold colours so it's obviously interactive. */
+.md-typeset .rb-zoom-badge {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 5;
+  background: var(--primary, #0b2545);
+  color: #ffffff !important;
+  border: 0;
+  border-radius: 999px;
+  padding: 7px 14px;
+  font-family: Inter, system-ui, sans-serif;
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  box-shadow: 0 6px 18px rgba(2, 6, 23, 0.25);
+  opacity: 1;
+  transition: background 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
+  pointer-events: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.md-typeset .rb-zoom-badge:hover {
+  background: #123b6a;
+  transform: translateY(-1px);
+  box-shadow: 0 8px 22px rgba(2, 6, 23, 0.32);
+}
+
+/* Full-screen overlay. */
+#rb-mermaid-lightbox {
+  position: fixed;
+  inset: 0;
+  background: rgba(11, 22, 48, 0.92);
+  backdrop-filter: blur(6px);
+  z-index: 99999;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 48px 56px;
+  box-sizing: border-box;
+  opacity: 1;
+}
+
+#rb-mermaid-lightbox.rb-lb-open {
+  display: flex !important;
+}
+
+/* SVG stage — takes up the whole modal and hosts the cloned SVG. */
+#rb-mermaid-lightbox .rb-lb-stage {
+  width: 95vw;
+  height: 90vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  cursor: grab;
+  user-select: none;
+}
+
+/* When a mermaid diagram is moved into the stage, wrap it visually in a
+   white card so the diagram's gray arrows, subgraph borders and labels
+   are readable against the dark backdrop. */
+#rb-mermaid-lightbox .rb-lb-stage > div.mermaid {
+  background: #ffffff;
+  padding: 28px 32px;
+  border-radius: 14px;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
+}
+
+/* The cloned content (SVG or div). max-width / max-height keep it
+   within the modal; transform-origin so wheel-zoom centers correctly. */
+#rb-mermaid-lightbox .rb-lb-stage > * {
+  max-width: 100%;
+  max-height: 100%;
+  width: auto;
+  height: auto;
+  transform-origin: center center;
+  transition: transform 0.08s ease-out;
+  pointer-events: auto;
+}
+
+#rb-mermaid-lightbox .rb-lb-stage svg {
+  display: block;
+}
+
+/* Close button. */
+#rb-mermaid-lightbox .rb-lb-close {
+  position: absolute;
+  top: 18px;
+  right: 22px;
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  color: #fff;
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  font-size: 1.6rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.15s ease;
+  z-index: 2;
+}
+
+#rb-mermaid-lightbox .rb-lb-close:hover {
+  background: rgba(255, 255, 255, 0.22);
+  transform: scale(1.08);
+}
+
+/* Bottom hint. */
+#rb-mermaid-lightbox .rb-lb-hint {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 18px;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.7);
+  font-family: Inter, system-ui, sans-serif;
+  font-size: 0.85rem;
+  pointer-events: none;
+  user-select: none;
+}
+
+@media (max-width: 720px) {
+  .rb-zoom-badge {
+    font-size: 0.72rem;
+    padding: 5px 10px;
+  }
+
+  #rb-mermaid-lightbox {
+    padding: 16px 16px 40px;
+  }
+
+  #rb-mermaid-lightbox .rb-lb-stage {
+    width: 100vw;
+    height: 84vh;
+  }
+}

--- a/docs/development/manipulation/.pages
+++ b/docs/development/manipulation/.pages
@@ -1,0 +1,9 @@
+title: Manipulation
+nav:
+    - overview.md
+    - setup.md
+    - architecture.md
+    - packages.md
+    - tasks.md
+    - interfaces.md
+    - spotlights.md

--- a/docs/development/manipulation/architecture.md
+++ b/docs/development/manipulation/architecture.md
@@ -1,0 +1,353 @@
+---
+title: Architecture
+---
+
+# Architecture
+
+How the manipulation stack is wired at runtime: which nodes come up, which interfaces they expose, and the exact data flow for each of the three core operations — **pick**, **place**, **pour**.
+
+!!! abstract "TL;DR"
+    - `manipulation_core` is the single entry point for task managers. Everything below it is internal.
+    - The pick / place / pour pipelines are coordinated by **Managers** that call perception → grasp generation → motion in sequence.
+    - All motion goes through `motion_planning_server`, which wraps MoveIt 2.
+    - Endpoint names and tuning constants live in `frida_constants` — **never** hard-code them.
+
+## Node graph
+
+A complete `ros2 launch pick_and_place pick_and_place.launch.py` brings up these nodes:
+
+```mermaid
+flowchart TB
+    subgraph manipulation
+        MC[manipulation_core]
+        PS[pick_server]
+        PLS[place_server]
+        PRS[pour_server]
+        MP[motion_planning_server]
+        FP[fix_position_to_plane]
+        HP[heatmap_place_service]
+        FGE[flat_grasp_estimator]
+    end
+
+    subgraph perception
+        PP[pick_primitives]
+        PLN[plane_service]
+        ORC[test_only_orchestrator]
+        DS[down_sample_pc]
+    end
+
+    subgraph third_party
+        GPD[gpd_service]
+        MG[move_group<br/>MoveIt 2]
+        XA[xarm_driver]
+        JSP[joint_state_publisher]
+        RSP[robot_state_publisher]
+    end
+
+    subgraph vision_external
+        DH["DetectionHandler<br/>/vision/detection_handler"]
+    end
+
+    TM[task_manager] -->|ManipulationAction| MC
+    MC --> PS
+    MC --> PLS
+    MC --> PRS
+    MC -->|PickPerceptionService| ORC
+    MC -->|PlacePerceptionService| ORC
+    MC -->|HeatmapPlace| HP
+    MC -->|GraspDetection| GPD
+    MC -->|DetectionHandler| DH
+    ORC --> PP
+    ORC --> PLN
+    PS -->|MoveToPose| MP
+    PLS -->|MoveToPose| MP
+    PRS -->|MoveToPose| MP
+    MP -->|move_group_interface| MG
+    MG --> XA
+    DS --> ORC
+    DS --> PLN
+    style MC fill:#1e88e5,color:#fff
+    style TM fill:#43a047,color:#fff
+    style XA fill:#fb8c00,color:#fff
+    style DH fill:#9c27b0,color:#fff
+```
+
+### Full launch chain
+
+```
+ros2 launch manipulation_general <task>.launch.py
+├── arm_pkg/frida_moveit_config.launch.py
+│   ├── xarm_description/_robot_description.launch.py
+│   ├── arm_pkg/frida_moveit_common.launch.py     ← move_group + planning scene + RViz
+│   ├── xarm_controller/_ros2_control.launch.py
+│   ├── joint_state_publisher
+│   └── perception_3d/downsample_pc.launch.py
+└── pick_and_place/pick_and_place.launch.py
+    ├── gpd_service                                (arm_pkg)
+    ├── manipulation_core
+    ├── pick_server
+    ├── place_server
+    ├── pour_server
+    ├── perception_3d/perception_3d.launch.py
+    │   ├── pick_primitives
+    │   ├── plane_service
+    │   └── test_only_orchestrator
+    ├── heatmap_place_service                      (place)
+    ├── motion_planning_server                     (frida_motion_planning)
+    ├── fix_position_to_plane                      (pick_and_place)
+    └── flat_grasp_estimator                       (perception_3d)
+```
+
+## Public surface
+
+Task managers should interact with manipulation only through:
+
+| Type | Constant | Endpoint | Goal type |
+|---|---|---|---|
+| **Action** | `MANIPULATION_ACTION_SERVER` | `/manipulation/manipulation_action_server` | `frida_interfaces/action/ManipulationAction` |
+| **Action** | `GO_TO_HAND_ACTION_SERVER` | `/manipulation/go_to_hand_action_server` | `frida_interfaces/action/GoToHand` |
+
+Everything below those — `MoveToPose`, `MoveJoints`, `PickMotion`, `PlaceMotion`, `PourMotion`, collision-scene services — is **internal**. Task-manager code should not call them directly.
+
+!!! example "How to call `ManipulationAction` from a task manager"
+
+    ```python
+    from rclpy.action import ActionClient
+    from frida_interfaces.action import ManipulationAction
+    from frida_interfaces.msg import ManipulationTask
+    from frida_constants.manipulation_constants import MANIPULATION_ACTION_SERVER
+
+    client = ActionClient(node, ManipulationAction, MANIPULATION_ACTION_SERVER)
+    client.wait_for_server()
+
+    goal = ManipulationAction.Goal()
+    goal.task_type = ManipulationTask.PICK
+    goal.pick_params.object_name = "bottle"
+    goal.scan_environment = False
+    future = client.send_goal_async(goal)
+    ```
+
+## Pick — sequence diagram
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant TM as task_manager
+    participant MC as manipulation_core
+    participant PM as PickManager
+    participant V as DetectionHandler (vision)
+    participant P3 as perception_3d
+    participant GPD as gpd_service
+    participant PS as pick_server
+    participant MP as motion_planning_server
+
+    TM->>MC: ManipulationAction(task_type=PICK, object_name="bottle")
+    MC->>MC: clear_octomap (unless scan_environment)
+    MC->>MC: remove_all_collision_objects
+    MC->>PM: execute(object_name)
+    PM->>MP: MoveJoints(table_stare)
+    PM->>V: DetectionHandler(label="bottle")
+    V-->>PM: PointStamped (3D point)
+    PM->>P3: PickPerceptionService(point)
+    P3-->>PM: cluster cloud + collision primitives
+    PM->>GPD: GraspDetection(cluster)
+    GPD-->>PM: ranked grasp poses + scores
+    PM->>PS: PickMotion(grasps)
+    PS->>MP: MoveToPose(approach, 10 cm above)
+    PS->>MP: MoveToPose(grasp, cartesian descent)
+    PS->>PS: close_gripper
+    PS->>MP: AttachCollisionObject(object)
+    PS->>MP: MoveToPose(lift, SAFETY_HEIGHT)
+    PS->>MP: MoveJoints(nav_pose)
+    PS-->>PM: success + PickResult
+    PM-->>MC: success + PickResult
+    MC-->>TM: ManipulationAction.Result(success=True)
+```
+
+??? note "Cutlery sub-path"
+    If `object_name ∈ {fork, knife, spoon, cutlery}` (constant `CUTLERY_NAMES`), `PickManager` skips the GPD path:
+
+    1. Move to `cutlery_stare`.
+    2. Subscribe to `/manipulation/flat_grasp_pose` and average ≥10 samples.
+    3. Send the averaged pose to `pick_server`, which performs a **force-guarded descent** (xArm mode 5, ~20 mm/s, abort on joint-effort threshold).
+
+## Place — sequence diagram
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant TM as task_manager
+    participant MC as manipulation_core
+    participant PLM as PlaceManager
+    participant P3 as perception_3d
+    participant HP as heatmap_place_service
+    participant FP as fix_position_to_plane
+    participant PLS as place_server
+    participant MP as motion_planning_server
+
+    TM->>MC: ManipulationAction(task_type=PLACE, place_params)
+    MC->>PLM: execute(place_params, pick_result)
+    PLM->>MP: MoveJoints(table_stare) (unless is_shelf)
+    PLM->>P3: PlacePerceptionService(place_params)
+    P3-->>PLM: table cloud
+    PLM->>HP: HeatmapPlace(cloud, prefer_closest, special_request)
+    HP-->>PLM: PointStamped place_point
+    PLM->>FP: snap pose to plane
+    FP-->>PLM: adjusted pose
+    PLM->>PLS: PlaceMotion(place_pose, object_name)
+    PLS->>MP: MoveToPose(approach, above place_point)
+    PLS->>MP: MoveToPose(place, descend)
+    PLS->>PLS: open_gripper
+    PLS->>MP: DetachCollisionObject
+    PLS->>MP: MoveToPose(lift)
+    PLS-->>PLM: success
+    PLM-->>MC: success
+    MC-->>TM: ManipulationAction.Result(success=True)
+```
+
+## Pour — sequence diagram
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant TM as task_manager
+    participant MC as manipulation_core
+    participant PRM as PourManager
+    participant V as DetectionHandler
+    participant P3 as perception_3d
+    participant PRS as pour_server
+    participant MP as motion_planning_server
+
+    TM->>MC: ManipulationAction(task_type=POUR, pour_params)
+    MC->>PRM: execute(object, bowl, object_already_grasped)
+    PRM->>MP: MoveJoints(table_stare)
+    alt object_already_grasped == False
+        PRM->>V: DetectionHandler(object)
+        V-->>PRM: object_point
+        Note over PRM: ...full pick sub-sequence...
+    end
+    PRM->>V: DetectionHandler(bowl)
+    V-->>PRM: bowl_point
+    PRM->>P3: cluster bowl (no primitives)
+    P3-->>PRM: bowl cluster (for centroid + rim)
+    PRM->>PRS: PourMotion(pour_pose, pick_result)
+    PRS->>MP: MoveToPose(above bowl, tilt sequence)
+    PRS->>MP: MoveToPose(upright again)
+    PRS-->>PRM: success
+    PRM-->>MC: success
+    MC-->>TM: ManipulationAction.Result(success=True)
+```
+
+## Endpoint reference (constants)
+
+All names live in `frida_constants/manipulation_constants.py`. Import them; do not hard-code.
+
+### Actions
+
+| Constant | Endpoint |
+|---|---|
+| `MANIPULATION_ACTION_SERVER` | `/manipulation/manipulation_action_server` |
+| `PICK_MOTION_ACTION_SERVER` | `/manipulation/pick_motion_action_server` |
+| `PLACE_MOTION_ACTION_SERVER` | `/manipulation/place_motion_action_server` |
+| `POUR_MOTION_ACTION_SERVER` | `/manipulation/pour_motion_action_server` |
+| `MOVE_TO_POSE_ACTION_SERVER` | `/manipulation/move_to_pose_action_server` |
+| `MOVE_JOINTS_ACTION_SERVER` | `/manipulation/move_joints_action_server` |
+| `GO_TO_HAND_ACTION_SERVER` | `/manipulation/go_to_hand_action_server` |
+
+### Services
+
+| Constant | Endpoint | Owned by |
+|---|---|---|
+| `GRASP_DETECTION_SERVICE` | `/manipulation/detect_grasps` | `gpd_service` |
+| `PICK_PERCEPTION_SERVICE` | `/manipulation/pick_perception_service` | `test_only_orchestrator` |
+| `PLACE_PERCEPTION_SERVICE` | `/manipulation/place_perception_service` | `test_only_orchestrator` |
+| `HEATMAP_PLACE_SERVICE` | `/manipulation/heatmap_place_service` | `heatmap_place_service` |
+| `GRIPPER_SET_STATE_SERVICE` | `/manipulation/gripper/set_state` | gripper driver |
+| `ADD_COLLISION_OBJECT_SERVICE` | `/manipulation/add_collision_objects` | `motion_planning_server` |
+| `REMOVE_COLLISION_OBJECT_SERVICE` | `/manipulation/remove_collision_object` | `motion_planning_server` |
+| `ATTACH_COLLISION_OBJECT_SERVICE` | `/manipulation/attach_collision_object` | `motion_planning_server` |
+| `GET_COLLISION_OBJECTS_SERVICE` | `/manipulation/get_collision_objects` | `motion_planning_server` |
+| `TOGGLE_SERVO_SERVICE` | `/manipulation/toggle_servo` | `motion_planning_server` |
+| `GET_JOINT_SERVICE` | `/manipulation/get_joints` | `motion_planning_server` |
+| _(MoveIt built-in)_ | `/clear_octomap` | `move_group` |
+
+### Topics
+
+| Constant | Topic | Direction |
+|---|---|---|
+| `GRIPPER_GRASP_STATE_TOPIC` | `/gripper/grasp_state` | pub: gripper driver |
+| `PLACE_POINT_DEBUG_TOPIC` | `/manipulation/table_place_point_debug` | pub: heatmap |
+| `DEBUG_POSE_GOAL_TOPIC` | `/manipulation/debug_pose_goal` | pub: motion_planning_server |
+| `ZED_POINT_CLOUD_TOPIC` | `/zed/zed_node/point_cloud/cloud_registered` | sub: ZED |
+| — | `/manipulation/flat_grasp_pose` | pub: flat_grasp_estimator |
+| — | `/manipulator/place_ee_link_pose` | pub: place_server |
+| — | `/clicked_point` | sub: manipulation_client (debug) |
+
+## Tuning constants
+
+| Constant | Default | Meaning |
+|---|---|---|
+| `PICK_VELOCITY` | `0.5` m/s | Maximum EE velocity during pick segments. |
+| `PICK_ACCELERATION` | `0.15` m/s² | Maximum EE acceleration. |
+| `PICK_PLANNER` | `"RRTConnect"` | Default OMPL planner. |
+| `SCAN_ANGLE_VERTICAL` | `30°` | Vertical sweep during shelf scan. |
+| `SCAN_ANGLE_HORIZONTAL` | `30°` | Horizontal sweep. |
+| `SAFETY_HEIGHT` | `0.05` m | Minimum lift above the object after grasp. |
+| `PICK_MIN_HEIGHT` | `0.04` m | Object floor below which we don't attempt to pick. |
+| `CUTLERY_PICK_MIN_HEIGHT` | `0.002` m | Same but for thin objects. |
+| `PICK_MAX_DISTANCE` | `1.0` m | Reject detections beyond this. |
+| `PLACE_MAX_DISTANCE` | `0.8` m | Heatmap search radius. |
+| `SHELF_MIN_REACH` | `0.40` m | Minimum reach for shelf picks. |
+| `SHELF_REACH_BASE` | `0.75` m | Linear reach model offset. |
+| `SHELF_REACH_SLOPE` | `0.25` | Linear reach model slope. |
+| `AIM_STRAIGHT_FRONT_QUAT` | `[0.650, -0.290, 0.636, -0.299]` | Frontal-aim orientation. |
+
+### Pick / Place perception constants
+
+| File | Constant | Default | Effect |
+|---|---|---|---|
+| `remove_plane.cpp` | `setMaxIterations` | `1000` | RANSAC iterations for plane fit. |
+| `remove_plane.cpp` | `setDistanceThreshold` | `0.03` m | RANSAC inlier tolerance. |
+| `remove_plane.cpp` | `setClusterTolerance` | `0.04` m (primary) | Euclidean cluster spacing. |
+| `remove_plane.cpp` | `setMinClusterSize` | `100` points | Reject smaller blobs. |
+| `remove_plane.cpp` | `setMaxClusterSize` | `25 000` points | Cap on the largest cluster. |
+| `down_sample_pc.cpp` | `small_size` | `0.01` m | Fine voxel leaf for picks. |
+| `down_sample_pc.cpp` | `large_size` | `0.10` m | Coarse voxel leaf for nav. |
+| `heatmapPlace_Server.py` | `grid_size` | `0.015` m | Heatmap cell size. |
+| `heatmapPlace_Server.py` | `heat_kernel_length` | `0.30` m | Gaussian span over free space. |
+| `heatmapPlace_Server.py` | `cool_kernel_length` | `0.15` m | Penalty span over occupied space. |
+| `heatmapPlace_Server.py` | `cool_multiplier` | `10.0` | Weight on obstacle penalty (vs. `heat_multiplier=1.0`). |
+
+## TF frames
+
+| Frame | Meaning |
+|---|---|
+| `link_base` | Arm base — most internal poses are expressed here. |
+| `base_link` | Mobile base. The heatmap expects input clouds in this frame. |
+| `link_eef` | Last link of the kinematic chain — default MoveIt target. |
+| `gripper_grasp_frame` | Gripper contact point. GPD grasp poses come back in this frame. |
+| `zed_left_camera_optical_frame` | Source frame of the ZED point cloud and depth image. |
+
+!!! warning "`link_eef` vs `gripper_grasp_frame`"
+    They differ by a known offset of `~0.09 m` (controlled by the `ee_link_offset` parameter on `pick_server`; default in the launch is `-0.09`). Forgetting this offset causes the gripper to descend through the table.
+
+## Octomap & `scan_environment`
+
+`manipulation_core` calls `clear_octomap` at the start of every action **unless** `goal.scan_environment == True`. When set to true (used for shelf picks), the core first calls `scan_environment()`, which sweeps `joint1` by `±SCAN_ANGLE_HORIZONTAL` and `joint5` by `±SCAN_ANGLE_VERTICAL` to populate the octomap with shelf geometry before planning.
+
+## Debug topics worth knowing
+
+| Topic | Use case |
+|---|---|
+| `/manipulation/flat_grasp_pose` | Live cutlery grasp candidate. |
+| `/gripper/grasp_state` | Whether the gripper currently has contact. |
+| `/manipulation/table_place_point_debug` | Last heatmap-selected place point. |
+| `/manipulator/place_ee_link_pose` | Last EE pose sent to a place. |
+| `/manipulation/debug_pose_goal` | Last pose goal received by motion_planning_server. |
+| `/manipulation/debug_object_point` | Pour: object 3D point. |
+| `/manipulation/debug_bowl_point` | Pour: bowl 3D point. |
+| `/manipulation/debug_bowl_centroid` | Pour: centroid of the bowl cluster. |
+| `/clicked_point` | RViz "Publish Point" → `manipulation_client` triggers a pick. |
+
+!!! tip "RViz first, code second"
+    For 80% of bugs, opening RViz and visualising the planning scene + the debug topics above is faster than reading the logs. Add these topics to your default RViz config.

--- a/docs/development/manipulation/interfaces.md
+++ b/docs/development/manipulation/interfaces.md
@@ -1,0 +1,446 @@
+---
+title: Interfaces
+---
+
+# Interfaces
+
+Reference for every `.action`, `.srv`, and `.msg` under `frida_interfaces/manipulation/`. Endpoint names live in [`frida_constants/manipulation_constants.py`](https://github.com/RoBorregos/home2/blob/main/frida_constants/frida_constants/manipulation_constants.py) — always import them, never hard-code.
+
+!!! abstract "Conventions used below"
+    - Each block reproduces the **exact** content of the corresponding `.action`/`.srv`/`.msg` file.
+    - Action sections are separated into Goal / Result / Feedback by the `---` lines.
+    - All distances are in meters, angles in radians (unless noted), velocities in m/s.
+
+## Top-level action
+
+### `ManipulationAction.action`
+
+The **only** action a task manager should call for picking / placing / pouring.
+
+```
+# Goal
+int8 task_type                # ManipulationTask.{PICK, PICK_CLOSEST, PLACE, POUR}
+PickParams pick_params
+PlaceParams place_params
+PourParams pour_params
+bool scan_environment         # if true, sweep + keep the octomap (used for shelves)
+---
+# Result
+int32 success                 # 1 on success, 0 on failure
+---
+# Feedback
+string execution_state        # human-readable progress
+```
+
+Server: `/manipulation/manipulation_action_server` (constant `MANIPULATION_ACTION_SERVER`).
+
+### `ManipulationTask.msg`
+
+```
+int8 PICK         = 0
+int8 PICK_CLOSEST = 1
+int8 PLACE        = 2
+int8 POUR         = 3
+```
+
+### `PickParams.msg`
+
+```
+geometry_msgs/PointStamped object_point   # optional explicit 3D point; ignored if object_name resolves via vision
+string object_name                        # label (must match a vision class or zero-shot input)
+float32 max_distance                      # detection filter bounds (m)
+float32 min_distance
+bool closest                              # prefer closest detection
+bool largest                              # prefer largest cluster
+bool in_configuration                     # if false, the arm will move to a stare pose first
+```
+
+### `PlaceParams.msg`
+
+```
+float32 table_height                      # override detected plane (m)
+float32 table_height_tolerance
+bool is_shelf                             # keep octomap, stay in current pose
+string close_to                           # name of a known object to bias toward
+string special_request                    # JSON, see below
+geometry_msgs/PoseStamped forced_pose     # if non-empty, skip heatmap and use this
+```
+
+??? example "`special_request` JSON examples"
+
+    ```json
+    {"request":"close_by","object":"sugar","position":"left"}
+    {"request":"close_by","object":"box","position":"front"}
+    ```
+
+    Valid `position` values: `close`, `front`, `back`, `left`, `right`.
+
+### `PourParams.msg`
+
+```
+string object_name              # what to pour (must be in POUR_OBJECT_NAMES if upright)
+string bowl_name                # what to pour into
+bool object_already_grasped     # if true, skip the pick stage
+```
+
+### `PickResult.msg`
+
+```
+geometry_msgs/PoseStamped pick_pose
+float32 grasp_score
+string object_name
+float32 object_pick_height      # detected object height (m)
+float32 object_height
+```
+
+## Internal motion actions
+
+### `PickMotion.action`
+
+```
+# Goal
+geometry_msgs/PoseStamped[] grasping_poses
+float64[]                   grasping_scores
+string                      object_name
+---
+# Result
+int32      success
+PickResult pick_result
+---
+# Feedback
+string execution_state
+```
+
+Server: `/manipulation/pick_motion_action_server`. Picks the best of `grasping_poses` (scored by `grasping_scores`) and executes approach / descend / grasp / lift.
+
+### `PlaceMotion.action`
+
+```
+# Goal
+geometry_msgs/PoseStamped place_pose
+string                    object_name
+PlaceParams               place_params
+---
+# Result
+int32 success
+---
+# Feedback
+string execution_state
+```
+
+Server: `/manipulation/place_motion_action_server`.
+
+### `PourMotion.action`
+
+```
+# Goal
+geometry_msgs/PoseStamped pour_pose
+frida_interfaces/PickResult pick_result
+bool                      object_already_grasped
+---
+# Result
+int32      success
+PickResult pour_result
+---
+# Feedback
+string execution_state
+```
+
+Server: `/manipulation/pour_motion_action_server`. The `PourParams` from the top-level action are unpacked by `manipulation_core`; the internal action receives the computed pour pose and the prior pick result.
+
+### `MoveToPose.action`
+
+```
+# Goal
+geometry_msgs/PoseStamped pose
+float32 velocity
+float32 acceleration
+float32 planning_time
+int32   planning_attempts
+float32 tolerance_position
+float32 tolerance_orientation
+string  planner_id
+string  target_link            # default: link_eef
+bool    apply_constraint
+frida_interfaces/Constraint constraint
+---
+# Result
+int32 success
+---
+# Feedback
+string execution_state
+```
+
+Server: `/manipulation/move_to_pose_action_server`.
+
+### `MoveJoints.action`
+
+```
+# Goal
+float64[] joint_positions
+string[]  joint_names           # if empty, joints in chain order
+float32   velocity
+float32   acceleration
+float32   planning_time
+int32     planning_attempts
+string    planner_id
+bool      apply_constraint
+frida_interfaces/Constraint constraint
+---
+# Result
+int32 success
+---
+# Feedback
+string execution_state
+```
+
+Server: `/manipulation/move_joints_action_server`.
+
+!!! warning "No `named_position` field on the action"
+    The Python helper `frida_motion_planning.utils.service_utils.move_joint_positions(named_position=...)` resolves the name from `frida_constants.xarm_configurations` and fills `joint_positions` before sending the goal.
+
+### `GoToHand.action`
+
+```
+# Goal
+geometry_msgs/PointStamped point
+float32 hand_offset 0.1
+---
+# Result
+int32 success
+---
+# Feedback
+string execution_state
+```
+
+Server: `/manipulation/go_to_hand_action_server`. Used by HRIC: vision publishes a hand point, the EE stops `hand_offset` short of it along the approach axis.
+
+## Services
+
+### Perception
+
+#### `PickPerceptionService.srv` *(test_only_orchestrator)*
+
+```
+geometry_msgs/PointStamped point
+bool                       add_collision_objects
+---
+sensor_msgs/PointCloud2 cluster_result
+```
+
+#### `PlacePerceptionService.srv` *(test_only_orchestrator)*
+
+```
+PlaceParams place_params
+---
+sensor_msgs/PointCloud2 cluster_result
+```
+
+#### `GraspDetection.srv` *(gpd_service)*
+
+```
+# Request
+string                  cfg_path
+string                  pcd_path
+sensor_msgs/PointCloud2 input_cloud
+---
+# Response
+bool                          success
+string                        message
+geometry_msgs/PoseStamped[]   grasp_poses
+float64[]                     grasp_scores
+```
+
+#### `HeatmapPlace.srv` *(heatmap_place_service)*
+
+```
+sensor_msgs/PointCloud2    pointcloud
+bool                       prefer_closest
+geometry_msgs/PointStamped close_point
+string                     special_request
+---
+geometry_msgs/PointStamped place_point
+bool                       success
+```
+
+#### `RemovePlane.srv` *(plane_service)*
+
+```
+bool                       extract_or_remove   # true → return the plane, false → return cloud minus plane
+geometry_msgs/PointStamped close_point         # optional
+float32                    min_height
+float32                    max_height
+---
+sensor_msgs/PointCloud2 cloud
+int32                   health_response
+```
+
+#### `RemoveVerticalPlane.srv` *(plane_service)*
+
+Same shape as `RemovePlane.srv` but targets vertical planes (walls, shelf backs).
+
+#### `ClusterObjectFromPoint.srv` *(plane_service)*
+
+```
+geometry_msgs/PointStamped point
+bool                       is_get_all_other_surrounding_objects
+---
+sensor_msgs/PointCloud2 cluster
+int32                   status
+```
+
+#### `AddPickPrimitives.srv` *(pick_primitives)*
+
+```
+sensor_msgs/PointCloud2 cloud
+bool                    is_plane
+bool                    is_object
+bool                    is_other_objects
+---
+uint32 status
+```
+
+#### `GetPlaneBbox.srv` *(pick_primitives)*
+
+```
+float32 min_height
+float32 max_height
+---
+geometry_msgs/PointStamped pt1
+geometry_msgs/PointStamped pt2
+geometry_msgs/PointStamped pt3
+geometry_msgs/PointStamped pt4
+geometry_msgs/PointStamped center
+geometry_msgs/PointStamped highest
+geometry_msgs/PointStamped lowest
+int32                      health_response
+bool                       state
+```
+
+### Motion planning scene *(motion_planning_server)*
+
+#### `AddCollisionObjects.srv`
+
+```
+frida_interfaces/CollisionObject[] collision_objects
+---
+bool success
+```
+
+#### `RemoveCollisionObject.srv`
+
+```
+string id
+bool   include_attached
+---
+bool success
+```
+
+#### `AttachCollisionObject.srv`
+
+```
+string   id
+string   attached_link
+string[] touch_links
+bool     detach
+---
+bool success
+```
+
+#### `GetCollisionObjects.srv`
+
+```
+---
+frida_interfaces/CollisionObject[] collision_objects
+bool                               success
+```
+
+### Arm state and motion
+
+#### `GetJoints.srv` *(motion_planning_server)*
+
+```
+---
+float32[] joint_positions
+string[]  joint_names
+```
+
+#### `ToggleServo.srv` *(motion_planning_server)*
+
+```
+bool enable
+---
+bool success
+```
+
+### Other
+
+#### `PlayTrayectory.srv` *(motion_planning_server)*
+
+Replays a recorded joint trajectory by name.
+
+#### `DockToHandle.srv` *(dock_to_handle.py)*
+
+Wraps the nav2 `Dock` action to align with a previously-published door handle pose.
+
+#### `Test.srv` *(plane_service)*
+
+```
+string base_name
+---
+int32 success
+```
+
+Internal smoke test.
+
+## Messages
+
+### `CollisionObject.msg`
+
+```
+string                    id
+string                    type
+geometry_msgs/PoseStamped pose
+geometry_msgs/Point       dimensions  # length, width, height
+shape_msgs/Mesh           mesh
+string                    path_to_mesh
+```
+
+### `Constraint.msg`
+
+```
+geometry_msgs/Quaternion orientation
+string                   frame_id
+string                   target_link
+float64[]                tolerance_orientation
+float64                  weight
+int32                    parameterization
+```
+
+### `GripperGraspState.msg`
+
+```
+bool object_detected
+```
+
+Published on `/gripper/grasp_state`.
+
+## Topic reference
+
+| Topic | Direction | Purpose |
+|---|---|---|
+| `/manipulation/flat_grasp_pose` | pub: `flat_grasp_estimator` | Live top-down cutlery grasp candidate. |
+| `/gripper/grasp_state` | pub: gripper driver | `GripperGraspState` — has-contact flag. |
+| `/manipulation/table_place_point_debug` | pub: `heatmap_place_service` | Last place point chosen. |
+| `/manipulation/debug_pose_goal` | pub: `motion_planning_server` | Last pose goal received. |
+| `/manipulator/place_ee_link_pose` | pub: `place_server` | Last EE pose used in a place. |
+| `/manipulation/debug_object_point` | pub: `PourManager` | Pour: object 3D point. |
+| `/manipulation/debug_bowl_point` | pub: `PourManager` | Pour: bowl 3D point. |
+| `/manipulation/debug_bowl_centroid` | pub: `PourManager` | Pour: bowl cluster centroid. |
+| `/clicked_point` | sub: `manipulation_client` | RViz click → trigger pick. |
+| `/clear_octomap` | service `std_srvs/Empty` | MoveIt octomap reset. |
+| `/zed/zed_node/point_cloud/cloud_registered` | sensor | Raw ZED point cloud (real robot). |
+| `/filtered_cloud` | filter | MoveIt self-filtered cloud (sim default input). |
+| `/point_cloud` | downsampled | Default input to perception. |
+
+For any name not in this table, grep `frida_constants/manipulation_constants.py` — it is the source of truth.

--- a/docs/development/manipulation/overview.md
+++ b/docs/development/manipulation/overview.md
@@ -1,33 +1,192 @@
-# Area Overview
-RoBorregos @Home's Object Manipulation area handles the robot's physical interaction with the environment, including objects and people. This area is crucial for tasks such as picking and placing objects, handling specific items (such as a watter bottle or a bag) and even interacting with people (receiving or giving objects). As such, this area leads 3 core technical areas of the robot:
-
-- **2D Vision**: Collaborating with the Vision area, it is used to identify and extract information from 2D images, such as object detection and segmentation.
-- **3D Perception**: Revolves around extracting environment and object information from 3D data.
-- **Motion Planning**: Integrates and develops motion planning algorithms to ensure the robot can move safely and efficiently in its environment.
-
-Given its requirements, this area also develops general tasks useful for other areas, providing methods for moving the arm, keeping the URDF and motion planning updated and collaborating in developing simulation environments.
-
-# Node Overview
-
-## General Nodes
-
-### Manipulation Server
-- Manages requests made for pick, place and other object interactions through the robot arm
-- Connects to every manipulation node, such as object detectors, 3D perception, motion planning and more. 
-
-### Object Detector 2D
-- Uses Computer Vision models to detect and segment objects in 2D images
-- Returns both 2D and 3D object locations  
-
-### Perception 3D
-Several nodes spawning capabilities such as:
-- Extracting surfaces and objects
-- Detecting and extracting object of interest' pointclouds and reconstructed meshes
-
-### Place Server
-- Incorporates algorithms to determine the best position for placing objects
-
-### Pick and Place Server
-- Calls and manages motion planning algorithms to pick and place objects
-
 ---
+title: Overview
+---
+
+# Manipulation
+
+The **Manipulation** area is responsible for every physical interaction FRIDA has with the world: picking and placing objects on tables and shelves, pouring liquids, handing objects to people, opening containers, and any other operation that uses the arm or gripper. It bridges three disciplines — **2D vision**, **3D perception**, and **motion planning** — behind a single ROS 2 action interface that every task manager calls.
+
+!!! tip "New to the area?"
+    Read this page first, then jump to **[Setup & Build](setup.md)** to get the stack running on your machine, and **[Running Tasks](tasks.md)** for your first end-to-end pick.
+
+## What this section contains
+
+<div class="grid cards" markdown>
+
+-   :material-rocket-launch:{ .lg .middle } **[Setup & Build](setup.md)**
+
+    ---
+
+    Clone the repo, bring up the manipulation Docker container, build the
+    workspace, and validate your environment.
+
+-   :material-graph-outline:{ .lg .middle } **[Architecture](architecture.md)**
+
+    ---
+
+    Node graph, sequence diagrams for pick / place / pour, the full list
+    of topics, services, actions, and tunable constants.
+
+-   :material-package-variant:{ .lg .middle } **[Packages](packages.md)**
+
+    ---
+
+    A tour through every package in `manipulation/packages/` — what it
+    does, what files matter, and which third-party libraries we vendor.
+
+-   :material-robot:{ .lg .middle } **[Running Tasks](tasks.md)**
+
+    ---
+
+    How to launch picks, places, pours, and the competition tasks.
+    Includes the interactive `keyboard_input.py` reference.
+
+-   :material-api:{ .lg .middle } **[Interfaces](interfaces.md)**
+
+    ---
+
+    Reference for every `.action`, `.srv`, and `.msg` in
+    `frida_interfaces/manipulation/`.
+
+-   :material-calendar-week:{ .lg .middle } **[Spotlights](spotlights.md)**
+
+    ---
+
+    Week-by-week development log going back to 2024.
+
+</div>
+
+## Hardware
+
+<div class="grid" markdown>
+
+| Component | Detail |
+|---|---|
+| **Arm** | UFactory **xArm 6** (6 DOF) |
+| **Gripper** | Custom 2-finger parallel gripper with fractal silicone fingers |
+| **3D Sensor** | Stereolabs **ZED 2** stereo camera |
+| **Compute (robot)** | NVIDIA **Jetson Orin** |
+| **Simulator** | **MuJoCo** (primary), Webots (exploratory) |
+| **Framework** | ROS 2 Humble, MoveIt 2, PCL, OpenCV |
+
+</div>
+
+The arm is driven by MoveIt 2 through the standard `follow_joint_trajectory` action. The custom gripper exposes a single boolean service (`/manipulation/gripper/set_state`) and a `GripperGraspState` topic indicating contact.
+
+## High-level pipeline
+
+A request from the task manager (for example, "pick the bottle") flows through these stages:
+
+```mermaid
+flowchart LR
+    TM[Task Manager] -->|ManipulationAction| MC[manipulation_core]
+    MC --> V[Vision<br/>DetectionHandler]
+    V -->|3D point of object| MC
+    MC --> P3D[perception_3d<br/>cluster + plane]
+    P3D -->|cluster cloud<br/>+ collision primitives| MC
+    MC --> GPD[gpd_service<br/>GPD grasp poses]
+    GPD -->|ranked grasps| MC
+    MC --> PS[pick_server]
+    PS --> MP[motion_planning_server<br/>MoveIt 2]
+    MP --> XA[xArm 6]
+    PS --> GR[gripper]
+    style TM fill:#1e88e5,color:#fff
+    style XA fill:#43a047,color:#fff
+    style GR fill:#43a047,color:#fff
+```
+
+`manipulation_core` is the orchestrator. Each request is delegated to a specialized **Manager** (`PickManager`, `PlaceManager`, `PourManager`) that coordinates detection, perception, grasp generation, and motion. All motion is executed by `motion_planning_server`, which wraps MoveIt 2 and the xArm driver.
+
+## The five technical pillars
+
+### :material-eye: 1 — 2D Vision (consumed)
+
+The Manipulation area does not own the 2D detectors, but it depends on them:
+
+- **DetectionHandler** (`vision`) — service `/vision/detection_handler` (constant `DETECTION_HANDLER_TOPIC_SRV`) returns the latest `ObjectDetectionArray` with `label_text`, `bbox`, and `point3d` for each detected object.
+- **Zero-shot detector** — published on `ZERO_SHOT_DETECTIONS_TOPIC` for objects outside the trained vocabulary.
+
+`PickManager` queries the handler to obtain the **3D point** of the target object before invoking 3D perception.
+
+### :material-cube-outline: 2 — 3D Perception ([`perception_3d`](packages.md#perception_3d))
+
+PCL-based C++ nodes:
+
+- **`plane_service`** — RANSAC plane segmentation (table / shelf). Returns a plane bbox and a filtered cloud (`distance_threshold = 0.03 m`, `max_iterations = 1000`).
+- **`pick_primitives`** — generates collision primitives from a cluster (box for the plane, spheres or mesh for the object) and pushes them into the MoveIt planning scene.
+- **`test_only_orchestrator`** — top-level orchestrator that chains the previous two and exposes the unified `PickPerceptionService` / `PlacePerceptionService` consumed by the managers.
+- **`flat_grasp_estimator.py`** — Python node specialized for **cutlery**. Uses depth + PCA on the ROI to compute a top-down grasp pose aligned with the principal axis.
+- **`down_sample_pc`** — voxel downsampling of the incoming ZED cloud (default leaf `0.01 m`, large-leaf nav variant `0.10 m`).
+
+### :material-hand-back-right: 3 — Grasp Pose Detection ([`gpd`](packages.md#gpd))
+
+The **GPD** library ([RoBorregos/gpd](https://github.com/RoBorregos/gpd) — fork of [atenpas/gpd](https://github.com/atenpas/gpd)) is registered in the repo as a submodule under `manipulation/packages/gpd/` and built into `/workspace/install/gpd` by `setup_gpd.sh`. It is exposed to ROS through `gpd_service` (in [`arm_pkg`](packages.md#arm_pkg)): given a cluster and a viewpoint, it returns a ranked list of `geometry_msgs/PoseStamped` grasp candidates.
+
+GPD is configured via `arm_pkg/config/frida_eigen_params_custom_gripper.cfg`, which encodes the gripper geometry, sampling and scoring parameters.
+
+### :material-routes: 4 — Motion Planning
+
+We use a **two-layer** stack:
+
+| Layer | Package | Responsibility |
+|---|---|---|
+| **Wrapper** | [`frida_motion_planning`](packages.md#frida_motion_planning) | Python action / service interface (`MoveToPose`, `MoveJoints`, collision-scene services, servo). |
+| **Backend** | MoveIt 2 + [`frida_pymoveit2`](packages.md#frida_pymoveit2) | Trajectory generation, kinematics, planning-scene management. Default planner: **RRTConnect**. |
+
+The arm runs on the **IKFast** analytical solver for xArm 6 (`xarm6_ikfast_plugin`) instead of KDL — significantly faster IK during pick planning.
+
+!!! info "About VAMP"
+    [VAMP](https://github.com/KavrakiLab/vamp) (Vector-Accelerated Motion Planning) integration was developed during the 2026 cycle on a feature branch but **is not in `main`** as of this writing. The supporting packages (`vamp`, `foam`, `cricket`) are therefore not part of the current build.
+
+### :material-hand-clap: 5 — Pick / Place / Pour ([`pick_and_place`](packages.md#pick_and_place))
+
+The core ROS layer the team maintains:
+
+- **`manipulation_core.py`** — exposes the top-level `ManipulationAction` and dispatches to managers.
+- **`pick_server.py`** — implements approach, descent, grasp, lift. Has a **force-guarded descent** mode for cutlery (xArm mode 5 + joint-effort threshold).
+- **`place_server.py`** — drives the place motion (top-down or shelf, optional `forced_pose`).
+- **`pour_server.py`** — drives pour motions, including a path for an object that is **already grasped**.
+- **`fix_position_to_plane.py`** — service that snaps a candidate pose down to the closest extracted plane.
+- **`HeatmapPlace`** service ([`place`](packages.md#place)) — generates the optimal place point using a Gaussian heatmap on the table cloud.
+
+## At-a-glance: where do I edit X?
+
+| To change… | Edit |
+|---|---|
+| The pick sequence (approach, descend, lift) | `pick_and_place/managers/PickManager.py` |
+| The place sequence | `pick_and_place/managers/PlaceManager.py` |
+| The pour sequence | `pick_and_place/managers/PourManager.py` |
+| Top-down descent / force guard (cutlery) | `pick_and_place/pick_server.py` |
+| MoveIt connection (velocity, planner, IK) | `frida_motion_planning/utils/MoveItPlanner.py` |
+| Named joint configurations (`table_stare`, `nav_pose`, …) | `frida_constants/xarm_configurations.py` |
+| Topic / service / action names | `frida_constants/manipulation_constants.py` |
+| GPD scoring / gripper geometry | `arm_pkg/config/frida_eigen_params_custom_gripper.cfg` |
+| Plane RANSAC parameters | `perception_3d/src/remove_plane.cpp` |
+| Cluster extraction parameters | `perception_3d/src/add_primitives.cpp` |
+| Heatmap (place pose) logic | `place/scripts/heatmapPlace_Server.py` |
+| URDF / SRDF / collision matrix | `robot_description/` + `arm_pkg/moveit_configs_builder.py` |
+| What launches for each competition task | `manipulation_general/launch/<task>.launch.py` |
+
+## Pre-requisites for new members
+
+Before opening a PR, make sure you are comfortable with:
+
+- [x] **ROS 2 Humble** basics — `ros2 node/topic/service/action`, parameters, launch files.
+- [x] **MoveIt 2** conceptually — planning scene, collision objects, planning groups, `move_group_interface`.
+- [x] The repo layout — `home2` is cloned with `--recursive`; vendored submodules are touched in **separate** PRs.
+- [x] Our **Docker workflow** ([Setup](setup.md)) — never `pip install` on the host, always work inside the container.
+- [x] `frida_constants` — never hard-code a topic / service name in Python; import the constant.
+
+## Glossary
+
+| Term | Meaning |
+|---|---|
+| **FRIDA** | Friendly Robotic Interactive Domestic Assistant — RoBorregos' @Home robot. |
+| **EE / end-effector** | The last link of the arm chain. Default frame: `link_eef`. The gripper contact point lives at `gripper_grasp_frame`. |
+| **GPD** | Grasp Pose Detection ([atenpas/gpd](https://github.com/atenpas/gpd)) — library that scores candidate grasp poses on a point cloud. |
+| **IKFast** | OpenRAVE / MoveIt analytical IK solver — replaces KDL for faster, deterministic inverse kinematics. |
+| **Octomap** | MoveIt's voxel-based occupancy map used for collision avoidance against arbitrary geometry. |
+| **Manager** | A Python class inside `pick_and_place/managers/` that owns the high-level logic of one operation (Pick / Place / Pour). |
+| **Stare pose** | A named joint configuration (`table_stare`, `cutlery_stare`, etc.) that places the camera at a known viewpoint before perception. |
+| **Cluster** | A connected component of the ZED point cloud, extracted by Euclidean clustering after plane removal. |
+| **Force-guarded descent** | xArm mode 5 + joint-effort threshold — used for cutlery so the gripper stops on table contact instead of slamming. |

--- a/docs/development/manipulation/packages.md
+++ b/docs/development/manipulation/packages.md
@@ -1,0 +1,339 @@
+---
+title: Packages
+---
+
+# Packages
+
+All manipulation code lives in `home2/manipulation/packages/`. This page is a directory of what each package is for, what executables it exposes, and which files you should learn first.
+
+!!! tip "Use this page as a reading map"
+    Start with [`pick_and_place`](#pick_and_place) and [`frida_motion_planning`](#frida_motion_planning) — together they cover ~80 % of day-to-day work. Move to [`perception_3d`](#perception_3d) and [`arm_pkg`](#arm_pkg) for low-level integrations.
+
+## Directory layout
+
+```
+manipulation/packages/                # contents of main as of the current commit
+├── arm_pkg                # MoveIt config + GPD service + grasp markers
+├── frida_motion_planning  # Python wrappers over MoveIt 2 (action servers)
+├── frida_pymoveit2        # FRIDA's xArm 6 binding for pymoveit2
+├── gpd                    # GPD C++ library (submodule → RoBorregos/gpd)
+├── manipulation_general   # Per-task launch files (gpsr, hric, ppc, …)
+├── mujoco_ros2_control    # ros2_control plugin for MuJoCo (submodule)
+├── mujoco_spawn           # Launches FRIDA inside MuJoCo
+├── perception_3d          # 3D perception (cluster, plane, primitives)
+├── pick_and_place         # Pick / Place / Pour servers and orchestrator
+├── place                  # Heatmap-based place pose generator
+├── pymoveit2              # Vendored pymoveit2 (submodule). Use frida_pymoveit2.
+├── xarm6_ikfast_plugin    # IKFast analytical IK plugin for xArm 6
+├── xarm_ros2              # xArm ROS 2 driver (submodule → RoBorregos/xarm_ros2)
+└── xarm_utils             # Small utilities and launch helpers for xArm
+```
+
+!!! info "About `vamp`, `foam`, `cricket`"
+    These packages have been **explored in feature branches** but **are not in `main`** as of this writing. If your local checkout has them as untracked directories, treat them as work-in-progress.
+
+---
+
+## arm_pkg { #arm_pkg }
+
+The **central configuration package** for the arm: MoveIt config builder, GPD service, gripper/IK YAMLs, RViz debug.
+
+=== "Layout"
+
+    ```
+    arm_pkg/
+    ├── arm_pkg/                    # Python configs (MoveIt builders)
+    │   ├── moveit_configs_builder.py
+    │   ├── moveit_configs_builder_sim.py
+    │   └── utils.py
+    ├── launch/
+    │   ├── frida_moveit_config.launch.py        ← top-level MoveIt launch
+    │   ├── frida_moveit_common.launch.py        ← shared fragment
+    │   ├── frida_fake_moveit_config.launch.py   ← fake controller variant
+    │   └── frida_driver.launch.py               ← driver only
+    ├── config/
+    │   ├── frida_eigen_params_custom_gripper.cfg          ← GPD prod config
+    │   ├── frida_eigen_params_custom_gripper_testing.cfg
+    │   ├── gpd_service.yaml         ← ROS params for gpd_service
+    │   ├── sensors_3d.yaml          ← OccupancyMapMonitor (octomap)
+    │   ├── joint_limits.yaml
+    │   └── xarm_params.yaml
+    ├── src/
+    │   ├── gpd_service.cpp          ← GraspDetection.srv server
+    │   └── gpd_test.cpp             ← CLI tester
+    ├── scripts/
+    │   ├── grasp_markers.py         ← RViz markers for debugging grasps
+    │   └── test_env.py
+    └── examples/
+        └── grasp_detection_example.py
+    ```
+
+=== "Key parameters"
+
+    Inside `frida_eigen_params_custom_gripper.cfg`:
+
+    - **`finger_width`**, **`hand_outer_diameter`**, **`hand_depth`** — match the physical gripper geometry.
+    - **`num_samples`**, **`approach_step`** — control GPD's sampling density.
+    - **`min_grasp_score`** — reject low-confidence grasps.
+
+    Inside `gpd_service.yaml`:
+
+    ```yaml
+    /**:
+      ros__parameters:
+        target_frame: "base_link"
+        pcd_default_frame: "base_link"
+        transform_timeout: 1.0
+    ```
+
+!!! info "Where GPD comes from"
+    The library is built from `manipulation/packages/gpd/` into `/workspace/install/gpd` by `setup_gpd.sh`. `arm_pkg/CMakeLists.txt` reads `GPD_INSTALL_DIR` to link against it.
+
+---
+
+## pick_and_place { #pick_and_place }
+
+The **heart** of the manipulation area. Owns `ManipulationAction` and all high-level managers.
+
+=== "Layout"
+
+    ```
+    pick_and_place/
+    ├── launch/pick_and_place.launch.py        ← brings up the full stack
+    └── pick_and_place/
+        ├── manipulation_core.py               ← ManipulationAction server
+        ├── manipulation_client.py             ← debug — picks at /clicked_point
+        ├── keyboard_input.py                  ← interactive REPL
+        ├── pick_server.py                     ← PickMotion + GoToHand
+        ├── place_server.py                    ← PlaceMotion
+        ├── pour_server.py                     ← PourMotion
+        ├── fix_position_to_plane.py
+        ├── managers/
+        │   ├── PickManager.py
+        │   ├── PlaceManager.py
+        │   └── PourManager.py
+        └── utils/
+            ├── grasp_utils.py                 ← filter/score GPD outputs
+            └── perception_utils.py            ← get_object_point, etc.
+    ```
+
+=== "Key files"
+
+    | File | What it does |
+    |---|---|
+    | `manipulation_core.py` | Top-level action server. Routes requests to managers. |
+    | `managers/PickManager.py` | Detection → cluster → grasp generation → pick motion. Has the cutlery sub-path. |
+    | `managers/PlaceManager.py` | Cluster → heatmap → place motion. Handles `forced_pose`, `is_shelf`, special requests. |
+    | `managers/PourManager.py` | Optional pick → bowl detection → tilt sequence. |
+    | `pick_server.py` | Approach / descend / grasp / lift. Force-guarded descent for cutlery. |
+    | `place_server.py` | Approach / descend / open / detach / lift. |
+    | `keyboard_input.py` | Interactive shell — see [Running Tasks](tasks.md#interactive-keyboard-tool). |
+
+See [Architecture → Pick sequence](architecture.md#pick-sequence-diagram) for the runtime flow.
+
+---
+
+## frida_motion_planning { #frida_motion_planning }
+
+Python wrappers around MoveIt 2. Speaks neither to vision nor perception — a pure motion layer.
+
+=== "Layout"
+
+    ```
+    frida_motion_planning/
+    ├── launch/
+    │   ├── motion_planning_server.launch.py
+    │   └── demo_ds4.launch.py                 ← joystick demo
+    ├── examples/
+    │   ├── call_pose_goal.py
+    │   ├── call_joint_goal.py
+    │   ├── add_collision_object.py
+    │   ├── remove_collision_object.py
+    │   ├── ex_orientation_path_constraint.py
+    │   ├── ds4_demo.py
+    │   └── look_at_example.py
+    └── frida_motion_planning/
+        ├── motion_planning_server.py          ← action servers + services
+        ├── utils/
+        │   ├── MoveItPlanner.py               ← pose / joint plan, IK
+        │   ├── MoveItServo.py                 ← servo (continuous)
+        │   ├── Planner.py / Servo.py          ← base classes
+        │   ├── XArmServices.py                ← xarm_api wrappers
+        │   ├── service_utils.py               ← gripper helpers, named joints
+        │   ├── tf_utils.py                    ← transform_pose, transform_point
+        │   └── ros_utils.py                   ← wait_for_future, QoS helpers
+        └── util_nodes/
+            └── record_joints_node.py          ← snapshot joint state to a service
+    ```
+
+=== "What `MotionPlanningServer` exposes"
+
+    | Endpoint | Type | Purpose |
+    |---|---|---|
+    | `/manipulation/move_to_pose_action_server` | `MoveToPose` action | Plan + execute to a pose. |
+    | `/manipulation/move_joints_action_server` | `MoveJoints` action | Plan + execute to joints (numeric). |
+    | `/manipulation/get_joints` | `GetJoints` service | Current joint state. |
+    | `/manipulation/add_collision_objects` | `AddCollisionObjects` service | Push `CollisionObject[]` to MoveIt. |
+    | `/manipulation/remove_collision_object` | `RemoveCollisionObject` service | Remove by id (optionally including attached). |
+    | `/manipulation/attach_collision_object` | `AttachCollisionObject` service | Attach to the gripper. |
+    | `/manipulation/get_collision_objects` | `GetCollisionObjects` service | List planning-scene objects. |
+    | `/manipulation/toggle_servo` | `ToggleServo` service | Enable/disable MoveIt 2 servo. |
+
+---
+
+## perception_3d { #perception_3d }
+
+PCL-based 3D perception. Mixed C++ / Python.
+
+=== "Layout"
+
+    ```
+    perception_3d/
+    ├── launch/
+    │   ├── perception_3d.launch.py     ← pick_primitives + plane_service + orchestrator
+    │   └── downsample_pc.launch.py
+    ├── src/
+    │   ├── add_primitives.cpp          ← cluster + collision primitives
+    │   ├── remove_plane.cpp            ← RANSAC plane segmentation
+    │   ├── masive_testin.cpp           ← test_only_orchestrator (top-level)
+    │   ├── down_sample_pc.cpp          ← voxel downsample
+    │   ├── publish_pcl.cpp             ← publish a PCD file
+    │   ├── publish_handle.cpp          ← door handle pose publisher
+    │   └── read_cluster.cpp            ← read a saved cluster PCD
+    ├── scripts/
+    │   ├── flat_grasp_estimator.py     ← cutlery grasp pose
+    │   ├── dock_to_handle.py           ← nav2 Dock-based alignment
+    │   └── record_relative_pose.py
+    ├── config/
+    │   └── relative_docking_pose.yaml
+    └── include/perception_3d/macros.hpp
+    ```
+
+=== "Services owned"
+
+    | Owner node | Services |
+    |---|---|
+    | `pick_primitives` | `AddPickPrimitives`, `GetPlaneBbox` |
+    | `plane_service` | `Test`, `RemovePlane`, `ClusterObjectFromPoint`, `RemoveVerticalPlane` |
+    | `test_only_orchestrator` | `PickPerceptionService`, `PlacePerceptionService` (the high-level entry points consumed by the managers) |
+
+=== "Tuning knobs"
+
+    | File | What to tune |
+    |---|---|
+    | `remove_plane.cpp` | RANSAC `setMaxIterations` (1000), `setDistanceThreshold` (0.03 m), Euclidean cluster `setClusterTolerance` (0.04 m), min/max cluster sizes. |
+    | `add_primitives.cpp` | Voxel leaf size for cluster downsampling; primitive shape choice (spheres vs mesh). |
+    | `down_sample_pc.cpp` | Per-call `small_size`, `medium_size`, `large_size` voxel leaves. |
+    | `flat_grasp_estimator.py` | `GRASP_SURFACE_OFFSET` (3 mm), `MIN_POINTS_FOR_PCA` (10), table-height buffer + outlier rejection. |
+
+---
+
+## place { #place }
+
+Pure-Python heatmap-based place pose finder.
+
+```
+place/
+├── scripts/heatmapPlace_Server.py         ← HeatmapPlace service
+└── place/
+    └── heatmap_generators/
+        └── close_by_generators.py         ← close_to / front / back / left / right
+```
+
+??? abstract "Algorithm (heatmap_place_service)"
+    1. Read the incoming `PointCloud2` (must be in `base_link`).
+    2. Filter points to a `PLACE_MAX_DISTANCE` (0.8 m) disk.
+    3. Rasterize into a 2D occupancy grid with `grid_size = 0.015 m`.
+    4. Convolve with a Gaussian **heat** kernel (`length = 0.3 m`, `weight = 1.0`) on free space.
+    5. Convolve with a Gaussian **cool** kernel (`length = 0.15 m`, `weight = 10.0`) on occupied space.
+    6. `final = heat - cool`, clipped to `[0, ∞)`.
+    7. If `prefer_closest`: multiply by an exponential closeness-to-origin map (cubed for sharper decay).
+    8. If `special_request` (JSON): apply directional or close-to overlay from `close_by_generators`.
+    9. Return the argmax as `PointStamped`.
+
+    Debug topics: `/manipulation/table_place_point_debug` and a saved PNG of the heatmap.
+
+---
+
+## manipulation_general { #manipulation_general }
+
+Per-task launch files. Each composes `arm_pkg/frida_moveit_config.launch.py` with `pick_and_place/pick_and_place.launch.py` plus task-specific extras.
+
+| Launch file | What it brings up |
+|---|---|
+| `ppc.launch.py` | MoveIt + full pick/place stack. **No extras.** Pick & Place Challenge. |
+| `gpsr.launch.py` | MoveIt + full pick/place stack + `follow_face_node`. |
+| `restaurant.launch.py` | MoveIt + full pick/place stack + `follow_face_node`. |
+| `hric.launch.py` | MoveIt + `motion_planning_server` + `follow_face_node` + `pick_server` (no place/pour). |
+| `receptionist.launch.py` | MoveIt + `motion_planning_server` + `follow_face_node`. No pick. |
+| `carry.launch.py` | MoveIt + `motion_planning_server` + a low-resolution downsampler for navigation. |
+
+!!! tip "Adding a new task"
+    Don't fork `pick_and_place.launch.py`. Compose existing launches in a new file inside `manipulation_general/launch/`.
+
+---
+
+## Simulation packages
+
+### mujoco_spawn { #mujoco_spawn }
+
+Bootstraps MuJoCo with FRIDA. `mujoco_sim_init.launch.py`:
+
+- Writes a `MJCF` scene to `/tmp/mujoco/main.xml`.
+- Starts MuJoCo.
+- Optionally launches MoveIt and perception inside the sim (`launch_moveit:=true`, `launch_perception:=true`).
+
+### mujoco_ros2_control { #mujoco_ros2_control }
+
+Vendored `ros2_control` plugin that lets MuJoCo expose the same controller interfaces as the real arm. Files of note:
+
+- `mjcf/scene.xml` — the FRIDA scene.
+- `scripts/xacro2mjcf.py`, `scripts/urdf2mjcf.py` — URDF → MJCF conversion.
+- `scripts/run_coacd.py` — convex decomposition of meshes (required for accurate MuJoCo collisions).
+
+---
+
+## gpd { #gpd }
+
+The Grasp Pose Detection C++ library — submodule pointing to [RoBorregos/gpd](https://github.com/RoBorregos/gpd) (a fork of [atenpas/gpd](https://github.com/atenpas/gpd)). Built into `/workspace/install/gpd` by `setup_gpd.sh`. Exposed to ROS through `arm_pkg`'s `gpd_service`.
+
+---
+
+## xArm packages
+
+### xarm_ros2
+
+Official xArm ROS 2 driver, vendored. Provides `xarm_api`, `xarm_controller`, `xarm_moveit_config`, `xarm_description`, `xarm_msgs`, `xarm_planner`, `xarm_moveit_servo`, `uf_ros_lib`, and the C++ SDK under `xarm_sdk/`.
+
+### xarm6_ikfast_plugin
+
+Generated IKFast analytical IK plugin for the xArm 6. Significantly faster than KDL for pick planning. Selected via the MoveIt kinematics YAML.
+
+### xarm_utils
+
+Small package with helper launches/utilities specific to our integration (mode switching, joint recording).
+
+---
+
+## pymoveit2 / frida_pymoveit2 { #frida_pymoveit2 }
+
+- **`pymoveit2`** — upstream Python MoveIt 2 wrapper, vendored.
+- **`frida_pymoveit2`** — our derivative with FRIDA-specific group names, IK frames, and named configurations.
+
+When wiring new motion code, prefer `frida_pymoveit2.robots.xarm6` — it has the right defaults. Touch upstream `pymoveit2` only when fixing a real bug.
+
+---
+
+## Quick rebuild reference
+
+```bash
+# In the manipulation container, /workspace
+build                                                # the alias — most common
+colcon build --symlink-install --packages-select arm_pkg
+colcon build --symlink-install --packages-select pick_and_place
+colcon build --symlink-install --packages-select frida_motion_planning
+colcon build --symlink-install --packages-select perception_3d place
+colcon build --symlink-install --packages-select xarm6_ikfast_plugin
+```
+
+For a full rebuild use the `build` alias (see [Setup](setup.md#rebuilding)).

--- a/docs/development/manipulation/setup.md
+++ b/docs/development/manipulation/setup.md
@@ -1,0 +1,315 @@
+---
+title: Setup & Build
+---
+
+# Setup & Build
+
+Every piece of manipulation code runs inside a **Docker container** managed by the top-level `./run.sh` script in [RoBorregos/home2](https://github.com/RoBorregos/home2). The host only needs Docker, Git, and — on a CUDA machine — the NVIDIA Container Toolkit.
+
+!!! danger "Do not install ROS / MoveIt / PCL on the host"
+    All dependencies live inside the container. Anything you install on the host risks polluting future runs and confusing teammates. If you need a tool, add it to the Dockerfile.
+
+## Prerequisites
+
+- [x] [Docker Engine](https://docs.docker.com/engine/install/) + Docker Compose plugin
+- [x] [Git](https://git-scm.com/downloads)
+- [x] [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html) (only on CUDA hosts)
+- [x] At least **30 GB** of free disk for the image and build artifacts
+
+## Cloning the repo
+
+```bash
+git clone --recursive https://github.com/RoBorregos/home2.git
+cd home2
+```
+
+!!! warning "Did you forget `--recursive`?"
+    Many vendored libraries (`gpd`, `vamp`, `foam`, `cricket`, `xarm_ros2`, `pymoveit2`, …) are submodules. If you cloned without `--recursive`, fix it now:
+
+    ```bash
+    git submodule update --init --recursive
+    ```
+
+## First run
+
+From the **root** of the repo:
+
+```bash
+./run.sh manipulation
+```
+
+Behind the scenes:
+
+```mermaid
+flowchart LR
+    A[./run.sh manipulation] --> B{Detect env}
+    B -->|nvidia-smi works| C[cuda]
+    B -->|tegra release file| D[l4t<br/>Jetson]
+    B -->|else| E[cpu]
+    C --> F[Build base image<br/>roborregos/home2:cuda_base]
+    D --> F
+    E --> F
+    F --> G[Build manipulation image<br/>roborregos/home2:manipulation-cuda]
+    G --> H[docker compose up<br/>home2-manipulation]
+    H --> I[docker exec — shell inside container]
+```
+
+Inside the container, the entry script sources ROS, the cached `frida_interfaces`, GPD, and the CycloneDDS profile, then drops you at `/workspace`. Subsequent runs reuse the existing container instantly.
+
+!!! info "Bind mounts"
+    Your local working tree is bind-mounted into `/workspace/src`. Edits on the host are visible immediately inside the container — Python changes need no rebuild.
+
+## Rebuilding
+
+=== "Workspace (most common)"
+
+    Inside the container, two equivalents exist:
+
+    **A. The `build` alias** in `docker/manipulation/.bash_aliases`:
+
+    ```bash
+    build
+    ```
+
+    expands to:
+
+    ```bash
+    cd /workspace \
+      && source frida_interfaces_cache/install/local_setup.bash \
+      && colcon build --symlink-install \
+           --packages-up-to manipulation_general \
+           --packages-ignore realsense_gazebo_plugin xarm_gazebo frida_interfaces
+    ```
+
+    **B. The wider build used by `./run.sh manipulation --build`** (also includes the IKFast plugin and `xarm_utils`):
+
+    ```bash
+    colcon build --symlink-install \
+      --packages-up-to manipulation_general xarm6_ikfast_plugin xarm_utils \
+      --packages-ignore realsense_gazebo_plugin xarm_gazebo frida_interfaces
+    ```
+
+    `frida_interfaces` is built once in a separate stage and **mounted** at
+    `/workspace/frida_interfaces_cache`. That is why we ignore it in both
+    invocations.
+
+=== "Single package"
+
+    ```bash
+    colcon build --symlink-install --packages-select pick_and_place
+    ```
+
+    Useful when iterating on one Python file. After the build, `source install/setup.bash`.
+
+=== "Interfaces (.msg / .srv / .action)"
+
+    When you edit a file under `frida_interfaces/manipulation/`, rebuild the
+    interfaces cache from the **host**:
+
+    ```bash
+    ./run.sh frida_interfaces
+    ```
+
+    Then back inside the manipulation container:
+
+    ```bash
+    build
+    ```
+
+=== "Docker image"
+
+    When `Dockerfile.<env>`, `apt`, or `pip` deps change:
+
+    ```bash
+    ./run.sh manipulation --build-image
+    ```
+
+=== "Clean rebuild"
+
+    Wipes `build/`, `install/`, `log/`, and the interfaces cache on the host:
+
+    ```bash
+    ./run.sh --clean
+    ./run.sh manipulation --build
+    ```
+
+## GPD setup
+
+GPD is a C++ library compiled from source. The container handles this on entry through `docker/manipulation/setup_gpd.sh`:
+
+1. If `manipulation/packages/gpd/build/` is missing, runs `cmake .. && make && sudo make install`.
+2. If the build dir exists but `/usr/local/include/gpd` is missing, recompiles + reinstalls.
+3. Otherwise no-op.
+
+`GPD_INSTALL_DIR=/workspace/install/gpd` is exported so `arm_pkg`'s CMake finds the library via `find_library(GPD_LIB …)`.
+
+??? bug "Build fails with `Library GPD not found`"
+
+    Force the install manually:
+
+    ```bash
+    . /home/ros/setup_gpd.sh
+    export GPD_INSTALL_DIR=/workspace/install/gpd
+    build
+    ```
+
+## CycloneDDS
+
+We use **CycloneDDS** instead of FastDDS. There are two profiles:
+
+| Profile | When | File |
+|---|---|---|
+| **Sim / localhost only** | Default when running everything on one machine | `docker/manipulation/cyclonedds_sim.xml` |
+| **Network (multi-host)** | When the dev PC talks to the robot over LAN | `cyclonedds.xml` (repo root) |
+
+=== "Bare-metal host (Orin or direct Linux install)"
+
+    Run once per machine:
+
+    ```bash
+    sudo bash setup_cyclonedds.sh <INTERFACE>
+    source ~/.bashrc
+    ```
+
+    Replace `<INTERFACE>` with the network interface name (`eno1`, `wlp2s0`, …). Find it via:
+
+    ```bash
+    ip -o link show | awk -F': ' '{print $2}'
+    ```
+
+=== "Docker host"
+
+    Run only the kernel-buffer tuning on the host:
+
+    ```bash
+    sudo bash setup_cyclonedds.sh --host-only <INTERFACE>
+    ```
+
+    Inside the container, the manipulation `.bash_aliases` exports the sim profile automatically:
+
+    ```bash
+    export CYCLONEDDS_URI=file:///workspace/src/docker/manipulation/cyclonedds_sim.xml
+    ```
+
+!!! tip "Why the sim profile uses localhost only"
+    The full pick stack spawns 20+ ROS nodes. WiFi multicast loopback is unreliable, so the sim profile forces unicast peers on `localhost`. It also raises `MaxAutoParticipantIndex` to 120 because the default of 9 is too small.
+
+## Simulation (MuJoCo)
+
+```mermaid
+flowchart LR
+    A[./run.sh simulation] --> B[mujoco container]
+    B --> C[ros2 launch mujoco_spawn<br/>mujoco_sim_init.launch.py]
+    C --> D[MuJoCo + ros2_control]
+
+    E[./run.sh manipulation] --> F[manipulation container]
+    F --> G[ros2 launch pick_and_place<br/>use_sim_time:=true]
+
+    D <-->|joint states / commands<br/>via /clock| G
+```
+
+=== "Bring up MuJoCo"
+
+    Open a second terminal and run:
+
+    ```bash
+    ./run.sh simulation
+    # inside the container:
+    ros2 launch mujoco_spawn mujoco_sim_init.launch.py \
+        launch_moveit:=true \
+        launch_perception:=true
+    ```
+
+=== "Launch the pick stack against the sim"
+
+    In the **manipulation** container:
+
+    ```bash
+    ros2 launch pick_and_place pick_and_place.launch.py \
+        use_sim_time:=true \
+        point_cloud_topic:=/filtered_cloud
+    ```
+
+!!! warning "`point_cloud_topic` matters"
+    On the real robot the default `/point_cloud` works. In MuJoCo, use `/filtered_cloud` (the MoveIt self-filtered topic). Otherwise the cluster picks up parts of the robot's own meshes.
+
+## Touching vendored packages
+
+The repo vendors several upstream projects. **Treat them like third-party code.** The complete list lives in `.gitmodules` at the repo root.
+
+| Package | Source on `main` | Notes |
+|---|---|---|
+| `gpd` | Submodule → [RoBorregos/gpd](https://github.com/RoBorregos/gpd) (fork of [atenpas/gpd](https://github.com/atenpas/gpd)). | Compiled by `setup_gpd.sh`. |
+| `pymoveit2` | Submodule → [RoBorregos/pymoveit2](https://github.com/RoBorregos/pymoveit2). | Used by the motion planning wrappers. Prefer editing **`frida_pymoveit2`** (in-tree) for FRIDA-specific changes. |
+| `xarm_ros2` | Submodule → [RoBorregos/xarm_ros2](https://github.com/RoBorregos/xarm_ros2) on branch `xarm_servicios_estable`. | Fork of [xArm-Developer/xarm_ros2](https://github.com/xArm-Developer/xarm_ros2) with our patches enabled. Rarely modify; touch only in a dedicated PR. |
+| `mujoco_ros2_control` | Submodule → [RoBorregos/mujoco_ros2_control](https://github.com/RoBorregos/mujoco_ros2_control) on branch `mujoco_servicios_estable`. | Touch only the FRIDA-specific MJCF scene files. |
+| `xarm6_ikfast_plugin` | In-tree (regular package). | Generated IKFast plugin for the xArm 6 (merged in PR [#856](https://github.com/RoBorregos/home2/pull/856)). Rebuilt only when DH params change. |
+| `frida_pymoveit2` | In-tree (regular package). | Our derivative of `pymoveit2` with xArm-6 group names, IK frames, and named configurations. |
+
+!!! danger "Don't bundle vendored changes with feature work"
+    Vendored-package changes go in dedicated PRs so reviewers can scope them. Mixing them with task-manager edits makes diffs unreadable.
+
+## Validation
+
+After your first build, run a quick sanity check:
+
+```bash
+# 1. ROS sees the workspace
+ros2 pkg list | grep pick_and_place
+
+# 2. The interfaces are sourced
+ros2 interface show frida_interfaces/action/ManipulationAction
+
+# 3. MoveIt launches cleanly
+ros2 launch arm_pkg frida_moveit_config.launch.py show_rviz:=true
+```
+
+If RViz opens with the FRIDA URDF loaded and no red errors in the terminal, you are ready to move on to [Running Tasks](tasks.md).
+
+## Troubleshooting
+
+??? failure "Container exits immediately"
+    Run `docker logs home2-manipulation` to see the failure. The usual cause is a stale `build/` from a different env. Run `./run.sh --clean` and retry.
+
+??? failure "`Library GPD not found. Check ENV variable GPD_INSTALL_DIR`"
+    GPD didn't install. Run `. /home/ros/setup_gpd.sh && export GPD_INSTALL_DIR=/workspace/install/gpd`, then `build`.
+
+??? failure "`Could not import frida_interfaces.action`"
+    The interfaces cache is stale. On the **host** run `./run.sh frida_interfaces`, then re-enter the manipulation container.
+
+??? failure "MoveIt: `No motion plan found` immediately on every plan"
+    The octomap is polluted. Clear it:
+
+    ```bash
+    ros2 service call /clear_octomap std_srvs/srv/Empty
+    ```
+
+??? failure "Failed to load IKFast plugin"
+    Build the plugin explicitly:
+
+    ```bash
+    colcon build --packages-select xarm6_ikfast_plugin
+    source install/setup.bash
+    ```
+
+??? failure "Spawning ros2_controllers timed out"
+    The xArm driver isn't up. Wait until `frida_moveit_config.launch.py` reports the controllers are loaded before launching `pick_and_place`.
+
+??? failure "Sim sees the robot as a giant point-cloud cluster"
+    You're consuming the raw cloud, not the self-filtered one. Add `point_cloud_topic:=/filtered_cloud` to the launch.
+
+??? failure "DDS nodes can't discover each other"
+    Confirm `CYCLONEDDS_URI` points at the right XML:
+
+    - Sim / single host → `docker/manipulation/cyclonedds_sim.xml`
+    - Multi-host on LAN → `cyclonedds.xml` (root)
+
+## Stop / clean lifecycle
+
+| Command | Effect |
+|---|---|
+| `./run.sh --stop` | Stop containers, keep state. |
+| `./run.sh --down` | Stop and remove containers + networks. |
+| `./run.sh --clean` | Delete `build/`, `log/`, `install/`, and the interfaces cache. |
+
+Once your environment runs cleanly, head to **[Running Tasks](tasks.md)**.

--- a/docs/development/manipulation/spotlights.md
+++ b/docs/development/manipulation/spotlights.md
@@ -1,116 +1,68 @@
 # Weekly Spotlights
 
-This page is a collection of weekly spotlights that highlight the progress of the Object Manipulation team. Each spotlight is a summary of the work done by the team in a week.
+This page is a collection of weekly spotlights that highlight the progress of the Object Manipulation team. Each spotlight is a summary of the work done by the team in a given week.
 
-Member status:
+Member-status legend used inline:
 
-- 🔍: Research
-- 💻: Development
-- 📝: Documentation
-- 🔄: Refactoring
-- 🔧: Bug fixing
-- 🤝: Participation in other subteam
+- 🔍 Research
+- 💻 Development
+- 📝 Documentation
+- 🔄 Refactoring
+- 🔧 Bug fixing
+- 🤝 Participation in other subteam
 
 ## 2026-04-07
 
-| Name     | Status     |
-| -------- | ------     |
-| Domínguez|  💻    |
-| Ale G.   |  🤝   | 
-| Fernando |  💻        |
-| Luis     |  💻       |
-| Emil     |  💻     |
-| Paola    |       |
-| Hector   |  💻     |
-| Efrain   |  💻     |
-
 **Done:**
 
-| Owners | Task |
-|------|------|
-| Efrain 💻| SImulation with MoveIt Implementation|
-| Luis 💻|  |
-| Dominguez 💻| Get the grasp_detector information from the custom gripper for grasp feedback |
-| Dominguez 💻| Pour Refactor for object already grasped |
-| Dominguez 💻| Improve picks |
-| Dominguez 💻| Workflow to ensure xarm_ros2 integrity |
-| Dominguez 💻| IKFast plugin IK analítico para xArm6 | 
+- **Efrain** 💻 — Simulation with MoveIt implementation.
+- **Domínguez** 💻 — Get the `grasp_detector` information from the custom gripper for grasp feedback.
+- **Domínguez** 💻 — Pour refactor for object-already-grasped flow.
+- **Domínguez** 💻 — Improve picks.
+- **Domínguez** 💻 — Workflow to ensure `xarm_ros2` integrity.
+- **Domínguez** 💻 — IKFast analytical IK plugin for xArm 6.
 
 **In Progress:**
 
-| Owners | Task |
-|------|------|
-| Dominguez 💻| Dense cloud data base integration with the grasp detector |
-| Dominguez 💻| Manipulation optimization |
-| Dominguez 💻| Testing Pick&Place Challenge |
-| Dominguez 💻| Apply grasp feedback logic in manipulation pipeline |
-| Efrain 💻| Connecting the Mujoco Simulation with the rest of nodes |
- |
+- **Domínguez** 💻 — Dense cloud database integration with the grasp detector.
+- **Domínguez** 💻 — Manipulation pipeline optimization.
+- **Domínguez** 💻 — Testing the Pick & Place Challenge.
+- **Domínguez** 💻 — Apply grasp-feedback logic in the manipulation pipeline.
+- **Efrain** 💻 — Connecting the MuJoCo simulation with the rest of the nodes.
 
 ## 2026-03-24
 
-| Name     | Status     |
-| -------- | ------     |
-| Domínguez|  💻    |
-| Ale G.   |  🤝   | 
-| Fernando |  💻        |
-| Luis     |  💻       |
-| Emil     |  💻     |
-| Paola    |       |
-| Hector   |  💻     |
-| Efrain   |  💻     |
-
 **Done:**
 
-| Owners | Task |
-|------|------|
-| Emil 💻| Throw trash and feature to drop objects on top of any other known object using its point cloud |
-| Fernando 💻 | Integration of “go to hand” into the task manager with vision hand detection and transforms between ZED and robot frames (working in HRIC task). |
-| Efrain 💻| Advanced in PR requirements and changes |
-| Luis 💻| Add dishwasher placement. |
-| Dominguez 💻| Right implementation of vamp with boxes published |
-| Dominguez 💻| First test of the Pick and Place Task Manager |
+- **Emil** 💻 — Throw-trash + drop-on-top-of-any-known-object using its point cloud.
+- **Fernando** 💻 — Integrate "go to hand" into the task manager with vision hand detection and ZED ↔ robot transforms (HRIC task).
+- **Efrain** 💻 — Advanced PR requirements and review changes.
+- **Luis** 💻 — Add dishwasher placement.
+- **Domínguez** 💻 — Correct implementation of VAMP with boxes published.
+- **Domínguez** 💻 — First test of the Pick & Place Task Manager.
 
 **In Progress:**
 
-| Owners | Task |
-|------|------|
-| Dominguez 💻| Developing collision avoidance with the octomap |
-| Dominguez 💻| Improving the pick cutlery logic |
-| Dominguez 💻| Pick and Place Task Manager improvements |
-| Luis 💻| Move follow face node. Test pour manager. |
-| Emil 💻| Development on the grasp of handles (Specifically for laundry basket) with initial approach for lifting  |
-| Hector 💻| Development on the open door task |
-| Efrain 💻| Test the point cloud in mujoco and its interaction with the pick |
-| Fernando 💻 | Fix plane collision (it generates rotation) |
-| Fernando 💻 | Search for a bag pose for navigation while holding a bag in the gripper |
-| Fernando 💻 | Open container? |
+- **Domínguez** 💻 — Collision avoidance with the octomap.
+- **Domínguez** 💻 — Improve the pick-cutlery logic.
+- **Domínguez** 💻 — Pick & Place Task Manager improvements.
+- **Luis** 💻 — Move follow-face node. Test pour manager.
+- **Emil** 💻 — Grasp of handles (laundry basket) with initial lift approach.
+- **Hector** 💻 — Open-door task.
+- **Efrain** 💻 — Test the point cloud in MuJoCo and its interaction with the pick.
+- **Fernando** 💻 — Fix plane collision (it generates rotation).
+- **Fernando** 💻 — Search for a bag pose for navigation while holding a bag in the gripper.
+- **Fernando** 💻 — Open container.
 
 ## 2026-03-10
 
-| Name     | Status     |
-| -------- | ------     |
-| Domínguez|  💻    |
-| Ale G.   |       | 
-| Ricardo  |        |
-| Fernando |  💻        |
-| Luis     |  💻       |
-| Emil     |  💻     |
-| Fregoso  |              |
-| Paola    |       |
-| Hector   |  💻     |
-| Efrain   |  💻     |
-
 **Done:**
 
-| Owners | Task |
-|------|------|
-| Dominguez 💻| Pick cutlery |
-| Hector 💻| Follow hand for grasping bag |
-| Emil 💻|Place on top of object |
-| Fernando 💻 | Go to hand and move to point action servers for HRIC "pick"(not pick) bag |
-| Efrain 💻| Mujoco: Fix add gripper controll by xarm_service |
-
+- **Domínguez** 💻 — Pick cutlery.
+- **Hector** 💻 — Follow hand for grasping bag.
+- **Emil** 💻 — Place on top of object.
+- **Fernando** 💻 — Go-to-hand and move-to-point action servers for HRIC "pick bag".
+- **Efrain** 💻 — MuJoCo: fix gripper control via `xarm_service`.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/nkaqR_LuLjs" title="Pick Cutlery" frameborder="0" allowfullscreen></iframe>
 
@@ -118,141 +70,72 @@ Member status:
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/_r7oWEvyoiY" title="Place on top" frameborder="0" allowfullscreen></iframe>
 
- *Mujoco Video in progess*
+*MuJoCo video in progress.*
 
 **In Progress:**
 
-| Owners | Task |
-|------|------|
-| Dominguez 💻| Test vamp integration with moveit |
-| Dominguez 💻| Test Pick and Place Task Manager | 
-| Luis 💻 | Test Pour / Research GraspNet to improve grasping and change the current implementation of gpd. |
-| Emil 💻| Test Place in trash / Placing in top of trashcans|
+- **Domínguez** 💻 — Test VAMP integration with MoveIt.
+- **Domínguez** 💻 — Test Pick & Place Task Manager.
+- **Luis** 💻 — Test pour; research GraspNet to replace current GPD.
+- **Emil** 💻 — Test "place in trash" / placing on top of trash cans.
 
-
-## 2026-03-3
-
-| Name     | Status     |
-| -------- | ------     |
-| Domínguez|  💻    |
-| Ale G.   |       | 
-| Ricardo  |        |
-| Fernando |  💻        |
-| Luis     |  💻       |
-| Emil     |  💻     |
-| Fregoso  |              |
-| Paola    |       |
-| Hector   |  💻     |
-| Efrain   |  💻     |
+## 2026-03-03
 
 **Done:**
 
-| Owners | Task |
-|------|------|
-| Dominguez 💻| Place Bag on the floor |
-| Dominguez 💻| Import vamp to moveit environment |
+- **Domínguez** 💻 — Place bag on the floor.
+- **Domínguez** 💻 — Import VAMP to MoveIt environment.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/eMPKwX4tec8" title="Vamp integration with with moveit test" frameborder="0" allowfullscreen></iframe>
-
+<iframe width="560" height="315" src="https://www.youtube.com/embed/eMPKwX4tec8" title="Vamp integration with moveit test" frameborder="0" allowfullscreen></iframe>
 
 **In Progress:**
 
-| Owners | Task |
-|------|------|
-| Dominguez 💻| Test vamp integration with moveit |
-| Dominguez 💻| Pick and Place Task Manager | 
-| Luis 💻 | Add interruption when impossible paths found. Reduced planning attempts. |
-| Emil 💻| Place on top of objects based on maximum z, and centroid for place trash and controllers on weboots |
-| Hector 💻| Follow hand for grasping bag |
-| Efrain 💻| Mujoco: Fix add gripper controll by xarm_service |
-| Fernando 💻 | Go to hand and move to point action servers for HRIC "pick"(not pick) bag |
+- **Domínguez** 💻 — Test VAMP integration with MoveIt.
+- **Domínguez** 💻 — Pick & Place Task Manager.
+- **Luis** 💻 — Add interruption when impossible paths are found; reduce planning attempts.
+- **Emil** 💻 — Place on top of objects (max-Z + centroid for trash place); controllers in Webots.
+- **Hector** 💻 — Follow hand for grasping bag.
+- **Efrain** 💻 — MuJoCo: fix gripper control via `xarm_service`.
+- **Fernando** 💻 — Go-to-hand + move-to-point action servers for HRIC "pick bag".
 
 ## 2026-02-24
-
-| Name     | Status     |
-| -------- | ------     |
-| Domínguez|  💻    |
-| Ale G.   |       | 
-| Ricardo  |        |
-| Fernando |  💻        |
-| Luis     |  💻       |
-| Emil     |  💻     |
-| Fregoso  |              |
-| Paola    |       |
-| Hector   |  💻     |
-| Efrain   |  💻     |
 
 **Done:**
 
 [![Implementation of ros2_control with mujoco](https://img.youtube.com/vi/iYlQffC8MkQ/0.jpg)](https://www.youtube.com/watch?v=iYlQffC8MkQ)
 
-| Owners | Task |
-|------|------|
-| Efrain 💻 | Fixed the gripper joint bug|
-| Fernando 💻 | Distance mask to only pick objects in range(minimum distance, maximum distance) MERGED|
+- **Efrain** 💻 — Fix the gripper joint bug.
+- **Fernando** 💻 — Distance mask: only pick objects within `[min_distance, max_distance]` (MERGED).
 
 **In Progress:**
 
-| Owners | Task |
-|------|------|
-| Dominguez 💻| Import vamp to moveit environment |
-| Dominguez 💻| Pick and Place Task Manager | 
-| Luis 💻 | Add interruption when impossible paths found. Reduced planning attempts.|
-| Emil 💻| Special request placing in top of objects based on maximum z, and centroid for place trash |
-| Hector 💻| Getting cluster of transparent objects|
-| Efrain 💻| Mujoco: Fix gripper_finger joints and its actuators for ros2_control|
-
+- **Domínguez** 💻 — Import VAMP to MoveIt environment.
+- **Domínguez** 💻 — Pick & Place Task Manager.
+- **Luis** 💻 — Add interruption when impossible paths are found; reduce planning attempts.
+- **Emil** 💻 — Special-request placing on top of objects (max-Z + centroid for trash place).
+- **Hector** 💻 — Cluster of transparent objects.
+- **Efrain** 💻 — MuJoCo: fix `gripper_finger` joints and actuators for `ros2_control`.
 
 ## 2026-02-17
 
-| Name     | Status     |
-| -------- | ------     |
-| Domínguez|  💻    |
-| Ale G.   |       | 
-| Ricardo  |        |
-| Fernando |  💻        |
-| Luis     |  💻       |
-| Emil     |  💻     |
-| Fregoso  |              |
-| Paola    |       |
-| Hector   |  💻     |
-| Efrain   |  💻     |
-
 **Done:**
 
-| Owners | Task |
-|------|------|
-| Dominguez, Ale G. 📝 | Fixed manipulation pages TDP2026 paper |
+- **Domínguez, Ale G.** 📝 — Fixed manipulation pages for the TDP 2026 paper.
 
 **In Progress:**
 
-| Owners | Task |
-|------|------|
-| Fernando 💻 | Distance mask to only pick objects in range(minimum distance, maximum distance) |
-| Dominguez 💻| Import vamp to moveit environment |
-| Luis 💻 | Add interruption when impossible paths found. Reduced planning attempts.|
-| Emil 💻| Webots: Add gripper, zed camera and xarm controller to Frida in Webots |
-| Hector 💻| Getting cluster of transparent objects|
-| Efrain 💻| Mujoco: Add the xarm controller and camera to Mujoco|
+- **Fernando** 💻 — Distance mask: only pick objects within `[min_distance, max_distance]`.
+- **Domínguez** 💻 — Import VAMP to MoveIt environment.
+- **Luis** 💻 — Add interruption when impossible paths are found; reduce planning attempts.
+- **Emil** 💻 — Webots: add gripper, ZED, and xArm controller to FRIDA.
+- **Hector** 💻 — Cluster of transparent objects.
+- **Efrain** 💻 — MuJoCo: add xArm controller and camera.
 
 ## 2026-01-29
 
-| Name     | Status     |
-| -------- | ------     |
-| Domínguez|  💻📝    |
-| Ale G.   |  📝     | 
-| Ricardo  |  💻      |
-| Fernando |  💻        |
-| Luis     |  💻       |
-| Emil     |  💻📝     |
-| Fregoso  |              |
-| Paola    |  📝     |
-| Hector   |  💻     |
-| Efrain   |  💻     |
-
 **Done:**
 
-- Vamp integration with Frida
+- VAMP integration with FRIDA.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/zVAVS99MIHA" title="Vamp integration with Frida (Test1)" frameborder="0" allowfullscreen></iframe>
 
@@ -260,638 +143,437 @@ Member status:
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/-7KqlR9u-SM" title="Vamp integration with Frida (Test3)" frameborder="0" allowfullscreen></iframe>
 
-- Imported Frida's URDF to Webots
+- Imported FRIDA's URDF to Webots.
 
-![image](../../assets/development/manipulation/spotlights/2026-02-05/fridaWebots.jpeg)
+![Frida in Webots](../../assets/development/manipulation/spotlights/2026-02-05/fridaWebots.jpeg)
 
-- Spherization of Frida's gripper and base for vamp implementation
-
-- Fixed manipulation pages TDP2026 paper
+- Spherization of FRIDA's gripper and base for VAMP.
+- Fixed manipulation pages of the TDP 2026 paper.
 
 **In Progress:**
 
-- Getting cluster of transparent objects
-- Import vamp to moveit environment
-- Working on simulation:
-    - Mujoco: Add the xarm controller to Mujoco
-    - Webots: Add gripper, zed camera and xarm controller to Frida in Webots
+- Cluster of transparent objects.
+- Import VAMP to MoveIt environment.
+- Simulation: MuJoCo (xArm controller) and Webots (gripper, ZED, xArm controller).
 
-## 2026-01-29
-
-| Name     | Status     |
-| -------- | ------     |
-| Domínguez|  💻📝    |
-| Ale G.   |  📝     | 
-| Ricardo  |  💻      |
-| Fernando |  💻        |
-| Luis     |  💻       |
-| Emil     |  💻📝     |
-| Fregoso  |              |
-| Paola    |  📝     |
-| Hector   |  💻     |
-| Efrain   |  💻     |
+## 2026-01-22
 
 **Done:**
 
-- Vamp integration with xarm
+- VAMP integration with xArm.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/XAExImV6TV4" title="Vamp integration with xarm" frameborder="0" allowfullscreen></iframe>
 
-- Webots connection with ROS2 for future manipulation implementation
+- Webots connection with ROS 2 for future manipulation implementation.
 
 **In Progress:**
 
-- Fixing the TDP2026 paper
-- Getting cluster of transparent objects
-- Vamp integration with Frida
-- Spherization of Frida's gripper and base for vamp implementation
-- Working on simulation:
-    - Mujoco: Add the xarm controller to Mujoco
-    - Webots: Spawn Frida in Webots
-
+- Fixing the TDP 2026 paper.
+- Cluster of transparent objects.
+- VAMP integration with FRIDA.
+- Spherization of FRIDA's gripper and base for VAMP.
+- Simulation: MuJoCo (xArm controller) and Webots (spawn FRIDA).
 
 ## 2026-01-15
 
-| Name     | Status     |
-| -------- | ------     |
-| Domínguez|  💻📝    |
-| Ale G.   |  📝     | 
-| Ricardo  |  💻      |
-| Fernando |  💻        |
-| Luis     |  💻       |
-| Emil     |  💻📝     |
-| Fregoso  |              |
-| Paola    |  📝     |
-| Hector   |  💻     |
-| Efrain   |  💻     |
-
 **Done:**
 
-- First manipulation meeting of 2026
+- First manipulation meeting of 2026.
 
 **In Progress:**
 
-- Fixing the TDP2026 paper
-- Getting cluster of transparent objects
-- Working on simulation
+- Fixing the TDP 2026 paper.
+- Cluster of transparent objects.
+- Working on simulation.
 
 ## 2025-11-21
 
-| Name     | Status     |
-| -------- | ------     |
-| Domínguez|  💻📝    |
-| Ale G.   |  📝     | 
-| Ricardo  |  💻      |
-| Fernando |  💻📝        |
-| Luis     |  💻📝        |
-| Emil     |  💻📝🔍     |
-| Fregoso  |              |
-| Paola    |  📝     |
-| Hector   |  💻     |
-
-**Main Priority:**
-
-- Add all the developments to the TDP2026 paper
+**Main priority:** add all developments to the TDP 2026 paper.
 
 **Done:**
 
--  Place objects around other objects (e.g. place cup at the right of zucaritas box)
--  Fixed repository dev/manipulation in the jetson orin
+- Place objects around other objects (e.g. place cup at the right of zucaritas box).
+- Fixed `dev/manipulation` repo on the Jetson Orin.
 
 **In Progress:**
 
-- Working on the TDP2026 paper
-- Correct and stabilize the follow face module to work in real time
-- Working on place trash action
-- Working on pick error
-- Fix octomap logic issues
-- Handle Exceptions in the manipulation pipeline
-- Implement vamp into the manipulation pipeline
-- Simulation:
-    - Mujoco: Add the environment of the receptionist to Mujoco
+- TDP 2026 paper.
+- Stabilize the follow-face module in real time.
+- Place-trash action.
+- Pick error.
+- Fix octomap logic issues.
+- Handle exceptions in the manipulation pipeline.
+- Implement VAMP in the manipulation pipeline.
+- Simulation: MuJoCo — receptionist environment.
 
-| Person | Assigned Tasks |
-| :--- | :--- |
-| **Domínguez** | `TDP2026 paper`, `Vamp integration`, `Mujoco environment` |
-| **Ale G.** | `TDP2026 paper` |
-| **Ricardo** | `Follow face module` |
-| **Fernando** |`Pick error`|
-| **Luis** |  `Octomap fix`, `Handle Exceptions` |
-| **Emil** | `TDP2026 paper`, `Place trash action` |
-| **Paola** | `TDP2026 paper` |
-| **Fregoso** | *(Pending)* |
-| **Hector** | `Detect transparent objects` |
+**Assignments:**
 
+- **Domínguez** — TDP 2026 paper, VAMP integration, MuJoCo environment.
+- **Ale G.** — TDP 2026 paper.
+- **Ricardo** — Follow-face module.
+- **Fernando** — Pick error.
+- **Luis** — Octomap fix, exception handling.
+- **Emil** — TDP 2026 paper, place-trash action.
+- **Paola** — TDP 2026 paper.
+- **Hector** — Detect transparent objects.
 
 ## 2025-11-14
 
-| Name     | Status     |
-| -------- | ------     |
-| Domínguez|  💻📝    |
-| Ale G.   |  📝     | 
-| Ricardo  |  💻      |
-| Fernando |  💻📝        |
-| Luis     |  💻📝        |
-| Emil     |  💻📝🔍     |
-| Fregoso  |              |
-| Paola    |  📝     |
-| Hector   |         |
-
-**Main Priority:**
-
-- Add all the developments to the TDP2026 paper
+**Main priority:** add all developments to the TDP 2026 paper.
 
 **Done:**
 
-- No major advances this week
+- No major advances this week.
 
 **In Progress:**
 
-- Working on the TDP2026 paper
-- Correct and stabilize the follow face module to work in real time
-- Working on place trash action
-- Working on pick error
-- Fix octomap logic issues
-- Handle Exceptions in the manipulation pipeline
-- Implement vamp into the manipulation pipeline
-- Simulation:
-    - Mujoco: Add the environment of the receptionist to Mujoco
+- TDP 2026 paper.
+- Stabilize the follow-face module in real time.
+- Place-trash action.
+- Pick error.
+- Fix octomap logic issues.
+- Handle exceptions in the manipulation pipeline.
+- Implement VAMP in the manipulation pipeline.
+- Simulation: MuJoCo — receptionist environment.
 
-| Person | Assigned Tasks |
-| :--- | :--- |
-| **Domínguez** | `TDP2026 paper`, `Vamp integration`, `Mujoco environment` |
-| **Ale G.** | `TDP2026 paper` |
-| **Ricardo** | `Follow face module` |
-| **Fernando** |`Pick error`, `Detect transparent objects`|
-| **Luis** |  `Octomap fix`, `Handle Exceptions` |
-| **Emil** | `TDP2026 paper`, `Place trash action` |
-| **Paola** | `TDP2026 paper` |
-| **Fregoso** | *(Pending)* |
-| **Hector** | *(Pending)* |
+**Assignments:**
 
+- **Domínguez** — TDP 2026 paper, VAMP integration, MuJoCo environment.
+- **Ale G.** — TDP 2026 paper.
+- **Ricardo** — Follow-face module.
+- **Fernando** — Pick error, detect transparent objects.
+- **Luis** — Octomap fix, exception handling.
+- **Emil** — TDP 2026 paper, place-trash action.
+- **Paola** — TDP 2026 paper.
 
 ## 2025-11-07
 
-| Name     | Status     |
-| -------- | ------     |
-| Domínguez|  💻📝    |
-| Ale G.   |  💻📝     | 
-| Ricardo  |  💻📝       |
-| Fernando |  💻📝        |
-| Luis     |  💻📝        |
-| Emil     |  💻📝🔍     |
-| Fregoso  |  💻📝       |
-| Paola    |  📝 🔍     |
-| Hector   |  💻📝       |
-
 **Done:**
 
-- Tested xarm sim with vamp
+- Tested xArm sim with VAMP.
 
 **In Progress:**
 
-- Correct and stabilize the follow face module to work in real time
-- Implement vamp into the manipulation pipeline
-- Working on the TDP2026 paper
-- Simulation:
-    - Mujoco: Add the environment of the receptionist to Mujoco
+- Stabilize the follow-face module in real time.
+- Implement VAMP in the manipulation pipeline.
+- TDP 2026 paper.
+- Simulation: MuJoCo — receptionist environment.
 
 ## 2025-10-16
 
-| Name     | Status     |
-| -------- | ------     |
-| Domínguez|  💻📝    |
-| Ale G.   |  💻📝     | 
-| Ricardo  |  💻📝       |
-| Fernando |  💻📝        |
-| Luis     |  💻📝        |
-| Emil     |  💻📝🔍     |
-| Fregoso  |  💻📝       |
-| Paola    |  📝 🔍     |
-| Hector   |  🤝         |
+**Done:**
 
-### Done
-- Unify movement control using only ROS (e.g. joint_trajectory) and delete manual modes in runtime.
-- Test with vamp
-![image](../../assets/development/manipulation/spotlights/2025_10_16/vamp.png)
-- Get point cloud from a transparent object in real time
+- Unify movement control through ROS only (e.g. `joint_trajectory`); delete manual modes at runtime.
+- Tested with VAMP.
 
-| Before | After |
-| :---: | :---: |
-| ![Perception 1](../../assets/development/manipulation/spotlights/2025_10_16/antes.jpeg) | ![Perception 2](../../assets/development/manipulation/spotlights/2025_10_16/despues.jpeg) |
+  ![VAMP test](../../assets/development/manipulation/spotlights/2025_10_16/vamp.png)
 
-### In Progress
-- Correct and stabilize the follow face module to work in real time
-- Implement vamp into the manipulation pipeline
-- Working on the TDP2026 paper
-- Simulation:
-    - Mujoco
-        - Add the environment of the receptionist to Mujoco
+- Get a point cloud from a transparent object in real time.
+
+  ![Before transparent-object handling](../../assets/development/manipulation/spotlights/2025_10_16/antes.jpeg)
+  ![After transparent-object handling](../../assets/development/manipulation/spotlights/2025_10_16/despues.jpeg)
+
+**In Progress:**
+
+- Stabilize the follow-face module in real time.
+- Implement VAMP in the manipulation pipeline.
+- TDP 2026 paper.
+- Simulation: MuJoCo — receptionist environment.
 
 ## 2025-10-09
 
-| Name     | Status     |
-| -------- | ------     |
-| Domínguez|  💻📝    |
-| Ale G.   |  💻📝     | 
-| Ricardo  |  💻📝       |
-| Fernando |  💻📝        |
-| Luis     |  💻📝        |
-| Emil     |  💻📝🔍     |
-| Fregoso  |  💻📝       |
-| Paola    |  📝 🔍     |
-| Hector   |  🤝         |
+**Done:**
 
-### Done
-- Test xarm with joint trajectory controller
-- Get point cloud from a transparent object
-- Inspect the pipeline and manage correctly the exceptions in each step
+- Tested xArm with joint trajectory controller.
+- Get a point cloud from a transparent object.
+- Inspect the pipeline and manage exceptions in each step.
 
-### In Progress
-- Unify movement control using only ROS (e.g. joint_trajectory) and delete manual modes in runtime.
-- Correct and stabilize the follow face module to work in real time
-- Working on the TDP2026 paper
-- Simulation:
-    - Mujoco
-        - Add the environment of the receptionist to Mujoco
+**In Progress:**
 
-
-
+- Unify movement control through ROS only.
+- Stabilize the follow-face module in real time.
+- TDP 2026 paper.
+- Simulation: MuJoCo — receptionist environment.
 
 ## 2025-10-02
 
-| Name     | Status     |
-| -------- | ------     |
-| Domínguez|  💻 📝    |
-| Ale G.   |  💻📝     | 
-| Ricardo  |  💻       |
-| Fernando |  💻        |
-| Luis     |  💻        |
-| Emil     |  💻 🔍     |
-| Fregoso  |  💻       |
-| Paola    |  📝 🔍     |
-| Hector   |  🤝         |
+**Done:**
 
-### Done
-- Added the urdf of Frida to Mujoco
+- Added FRIDA's URDF to MuJoCo.
 
-![image](../../assets/development/manipulation/spotlights/2025_10_2/MujocoUrdf.png)
+  ![FRIDA URDF in MuJoCo](../../assets/development/manipulation/spotlights/2025_10_2/MujocoUrdf.png)
 
-- Tests with clear grasps
+- Tests with clear grasps.
 
-![image](../../assets/development/manipulation/spotlights/2025_10_2/Clear.jpeg)
+  ![Clear grasps test](../../assets/development/manipulation/spotlights/2025_10_2/Clear.jpeg)
 
-- Onboarding
+- Onboarding.
 
-### In Progress
-- Unify movement control using only ROS (e.g. joint_trajectory) and delete manual modes in runtime.
-- Inspect the pipeline and manage correctly the exceptions in each step
-- Correct and stabilize the follow face module to work in real time
-- Remake the follow person module to improve the reliability and accuracy
-- Working on the TDP2026 paper
-- Simulation:
-    - Mujoco
-        - Add the environment of the receptionist to Mujoco
+**In Progress:**
+
+- Unify movement control through ROS only.
+- Inspect the pipeline and manage exceptions in each step.
+- Stabilize the follow-face module in real time.
+- Remake the follow-person module to improve reliability and accuracy.
+- TDP 2026 paper.
+- Simulation: MuJoCo — receptionist environment.
 
 ## 2025-09-26
 
-| Name     | Status     |
-| -------- | ------     |
-| Domínguez|  💻 📝    |
-| Ale G.   |  💻📝     | 
-| Ricardo  |  💻       |
-| Fernando |  💻        |
-| Luis     |  💻        |
-| Emil     |  💻 🔍     |
-| Fregoso  |  💻       |
-| Paola    |  📝 🔍     |
-| Hector   |  🤝         |
+**Done:**
 
-### Done
-- Already tried ClearGrasp with the realsense d435i camera
-- Mini OnBoarding 
+- Tried ClearGrasp with the RealSense D435i camera.
+- Mini onboarding.
 
-### In Progress
-- Unify movement control using only ROS (e.g. joint_trajectory) and delete manual modes in runtime.
-- Inspect the pipeline and manage correctly the exceptions in each step
-- Correct and stabilize the follow face module to work in real time
-- Remake the follow person module to improve the reliability and accuracy
-- Working on the TDP2026 paper
-- Simulation:
-    - Mujoco
-        - Add the urdf of Frida
-        - Add the environment of the receptionist to Mujoco
-        - Make a way that allow us to enter more than two people to different simulations
+**In Progress:**
+
+- Unify movement control through ROS only.
+- Inspect the pipeline and manage exceptions in each step.
+- Stabilize the follow-face module in real time.
+- Remake the follow-person module to improve reliability and accuracy.
+- TDP 2026 paper.
+- Simulation: MuJoCo — add FRIDA URDF, receptionist environment, multi-person sim.
 
 ## 2025-09-18
-### News
-New member:
-- Hector Tovar
 
-| Name     | Status     |
-| -------- | ------     |
-| Domínguez|  💻 📝    |
-| Ale G.   |  💻📝     | 
-| Ricardo  |  💻       |
-| Fernando |  💻        |
-| Luis     |  💻        |
-| Emil     |  💻 🔍     |
-| Fregoso  |  💻       |
-| Paola    |  📝 🔍     |
-| Hector   |  🤝         |
+**News:** new member — Hector Tovar.
 
-### Done
-- Investigation on how to detect a transparent container
-![image](../../assets/development/manipulation/spotlights/2025_09_18/ClearGrasp.png)
-- Optimize the downsampling and clustering to improve the speed and accuracy in detected objects
+**Done:**
 
-| Before | After |
-| :---: | :---: |
-| ![Perception 1](../../assets/development/manipulation/spotlights/2025_09_18/Perception1.jpg) | ![Perception 2](../../assets/development/manipulation/spotlights/2025_09_18/Perception2.jpg) |
+- Investigation on how to detect a transparent container.
 
-<!-- ![image](../../assets/development/manipulation/spotlights/2025_09_18/Perception1.jpg) ![image](../../assets/development/manipulation/spotlights/2025_09_18/Perception2.jpg) -->
-- Testing MuJoco for simulation
-![image](../../assets/development/manipulation/spotlights/2025_09_18/Mujoco.png)
+  ![ClearGrasp investigation](../../assets/development/manipulation/spotlights/2025_09_18/ClearGrasp.png)
 
-### In Progress
-- Unify movement control using only ROS (e.g. joint_trajectory) and delete manual modes in runtime.
-<!-- - Simplify and standardize the API to make it more intuitive and less prone to errors -->
-- Inspect the pipeline and manage correctly the expceptions in each step
-- Correct and stabilize the follow face module to work in real time
-- Remake the follow person module to improve the reliability and accuracy
-- Working on the TDP2026 paper
-- Simulation:
-    - Mujoco
-        - Add the urdf of Frida to Mujoco
-        - Add the environment of the receptionist to Mujoco
-        - Make a way that allow us to enter more than two people to different simulations
+- Optimize downsampling and clustering to improve speed and accuracy on detected objects.
+
+  ![Perception before](../../assets/development/manipulation/spotlights/2025_09_18/Perception1.jpg)
+  ![Perception after](../../assets/development/manipulation/spotlights/2025_09_18/Perception2.jpg)
+
+- Testing MuJoCo for simulation.
+
+  ![MuJoCo testing](../../assets/development/manipulation/spotlights/2025_09_18/Mujoco.png)
+
+**In Progress:**
+
+- Unify movement control through ROS only.
+- Inspect the pipeline and manage exceptions in each step.
+- Stabilize the follow-face module in real time.
+- Remake the follow-person module to improve reliability and accuracy.
+- TDP 2026 paper.
+- Simulation: MuJoCo — add FRIDA URDF, receptionist environment, multi-person sim.
 
 ## 2025-07-05
 
-### Done
-- Added environment spherization to avoid collisions near the object to pick
-- Increased pipeline reliability (fixed lots of hanging issues)
-- Tuned GPD for new gripper, now has a better success rate
-- Fully tested for storing groceries task
+**Done:**
 
-### In Progress
-- Trajectory recording as a file
-- Trajectory projection
-- Serving cereal on container real robot tests
+- Added environment spherization to avoid collisions near the object to pick.
+- Increased pipeline reliability (fixed many hanging issues).
+- Tuned GPD for the new gripper; better success rate.
+- Fully tested for the Storing Groceries task.
+
+**In Progress:**
+
+- Trajectory recording to file.
+- Trajectory projection.
+- Serving cereal on container — real-robot tests.
 
 ## 2025-06-25
 
-### News
-New members:
-- Paola Llamas
-- Emil Winkler
+**News:** new members — Paola Llamas and Emil Winkler.
 
-### Done
-- Onboarding
-- Tested new GPDs, decided to keep the current one
-- Pointcloud resolution based on distance to points
+**Done:**
 
-### In Progress
-- Decided on proposal to open doors, using recorded trajectories and adjusting for new observations
-- Clustering door handles
-- Serving cereal on container
+- Onboarding.
+- Tested new GPDs; decided to keep the current one.
+- Pointcloud resolution scaled by distance to points.
 
-## 2025-04-24 ---> TMR
-This includes both weeks last week from april and developments right before and during TMR 2025.
+**In Progress:**
 
-### News
-TMR2025 finished, manipulation team had ONE SUCCESFUL PICK on rounds.
+- Decided on a proposal to open doors using recorded trajectories adjusted for new observations.
+- Clustering door handles.
+- Serving cereal on container.
 
-### Done
+## 2025-04-24 — TMR
 
-- Place on shelfs done
-- New gripper fully tested and upgraded over previous pipeline
-- Added both vertical and horizontal grasping poses generation, tuned for new gripper
-- Fixed URDF precision issues
-- Tests with navigation and within task managers
+This entry covers the last week of April and developments right before and during TMR 2025.
 
+**News:** TMR 2025 finished; the manipulation team had **one successful pick** in the rounds.
+
+**Done:**
+
+- Place on shelves.
+- New gripper fully tested and upgraded over the previous pipeline.
+- Added both vertical and horizontal grasping pose generation, tuned for the new gripper.
+- Fixed URDF precision issues.
+- Tests with navigation and within task managers.
 
 ## 2025-04-24
 
-### News
-- Pick & Place on historic prime
+**News:** Pick & Place on historic prime.
 
-### Done
-- Place pipeline developed
-    - Has adaptability for any object size and table height
-    - Incorporated within pick code structure and ROS node, making it easy to use, develop and scale
-    - Tested on simulation and real robot
-- Heatmap extraction for place position
-    - Developed for Robocup 2024 but never used, works far better than previous KNN clustering
-![image](../../assets/development/manipulation/spotlights/2025_04_24/heatmap_result.png)
-- Pick and Place fully tested on real life
-    - Massive improvements on speed, obtained from collision object generation, reducing use of octomap and collision meshes and tuning GPD estimated grasp poses
-    - Planning times in comparison:
-        - Original MoveIt Pipeline (TMR2023, TDP2024): >1 minute
-        - Cartesian Planning (no collision detection, inferior working distance) (TMR2024, Robocup2024): ~20s
-        - New Moveit Pipeline (TMR2025): ~10s
-    - Octomap integrated within perception pipeline, enabling very safe pick and place operations
-    - Integrated on subtask manager for GPSR and Storing Groceries
-- New URDF for Simulation and Real robot
-    - Fixed for use on simulation
-    - Fixed a big issue which caused the pointcloud to be shifted ~3cm from its real position
-- Give & take operations for task manager
-- Improved face follower
-- Documentation and new easy to use launches for pick & place pipeline
+**Done:**
+
+- Place pipeline developed:
+    - Adaptable to any object size and table height.
+    - Incorporated within the pick code structure and ROS node — easy to use, develop, and scale.
+    - Tested on simulation and real robot.
+- Heatmap extraction for place position (developed for RoboCup 2024 but never used; works far better than the previous KNN clustering).
+
+  ![Heatmap result](../../assets/development/manipulation/spotlights/2025_04_24/heatmap_result.png)
+
+- Pick & Place fully tested in real life:
+    - Massive speed improvements from collision-object generation, reduced use of octomap and collision meshes, and tuning of GPD-estimated grasp poses.
+    - Planning times: MoveIt (TMR 2023, TDP 2024) > 1 min · Cartesian (TMR 2024, RoboCup 2024) ~20 s · new MoveIt pipeline (TMR 2025) ~10 s.
+    - Octomap integrated within the perception pipeline → safer pick/place.
+    - Integrated into the subtask manager for GPSR and Storing Groceries.
+- New URDF for simulation and real robot:
+    - Fixed for use on simulation.
+    - Fixed an issue that shifted the point cloud ~3 cm from its real position.
+- Give-&-take operations for the task manager.
+- Improved face follower.
+- Documentation and easy-to-use launches for the pick & place pipeline.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/VFtXomtwfvM" title="Pick and Place tests April 24, 2025" frameborder="0" allowfullscreen></iframe>
 
+**In Progress:**
 
-### In Progress
-- Robot still has issues picking big objects
-- Storing Groceries task involves placing on a difficult surface and at a high risk of colliding, which requires further testing
-- Plane extraction to generate a collision object for the table requires tuning to be working on a wider range of scenarios
+- Picking big objects reliably.
+- Storing Groceries — placing on a difficult surface with high collision risk.
+- Plane extraction for the table collision object — tuning for more scenarios.
 
 ## 2025-04-10
 
-### News
-- No news
+**Done:**
 
-### Done
-- Added simulation with real robot's ZED camera and gripper, working with 2D and 3D camera
-- Fixed transform time issues when deploying some scripts on simulation e.g. object detector.
-- Integrated the full pick pipeline with object detector 2D on simulation. Refactored the code to make it easier to use and to scale better for new tasks.
-- Tested pipeline on real robot with ZED camera
-    - Once again, sim-to-real was smooth without any logic changes
-    - Adjustements were made so all our heavy topics use "Best Effort" QoS policy which made real-robot tests possible -> receiving images and pointclouds through WiFi.
-    - Robot was not able to pick the object as some URDF changes are yet to be added.
+- Added simulation with real robot's ZED camera and gripper, working in 2D and 3D.
+- Fixed transform-time issues when deploying scripts on simulation (e.g. object detector).
+- Integrated the full pick pipeline with the 2D object detector on simulation; refactor for scalability.
+- Tested pipeline on the real robot with the ZED camera:
+    - Sim-to-real was smooth — no logic changes.
+    - Heavy topics moved to *Best Effort* QoS, enabling real-robot tests over Wi-Fi.
+    - Robot could not pick due to pending URDF changes.
 - Face follow tested and working.
-- New poses for Carry my Luggage and Receptionist
+- New poses for Carry My Luggage and Receptionist.
 
-![image](../../assets/development/manipulation/spotlights/spotlight_2025_04_10_pickreal.jpeg)
+![Real-world pick attempt](../../assets/development/manipulation/spotlights/spotlight_2025_04_10_pickreal.jpeg)
 
-### In Progress
-- CuRobo environment setup
-- Three issues were detected on Receptionist runs:
-    - Sometimes, planning hangs on the custom planning_server, not detecting planning failed and not returning a result.
-    - GetJoints service may return all 0s.
-    - MoveIt did not notics position all 0s as invalid even when it's on collision
+**In Progress:**
+
+- CuRobo environment setup.
+- Three issues on Receptionist runs:
+    - Planning hangs on the custom `planning_server`.
+    - `GetJoints` service may return all zeros.
+    - MoveIt sometimes doesn't flag all-zero positions as invalid.
 - Place pipeline with all services added.
-- URDF QoL changes.
+- URDF quality-of-life changes.
 
 ## 2025-04-03
 
-### News
-- No news
+**Done:**
 
-### Done
-- Cleaned up task manager, got some remaining things ready for receptionist
-- Fixed an issue where collision objects were collising among themselves
-- Heatmap for getting place position
+- Cleaned up task manager; readied remaining items for Receptionist.
+- Fixed collision objects colliding among themselves.
+- Heatmap for getting place position.
 
-### In Progress
-- CuRobo worked on PCs, environment on the Orin is not ready yet.
-- List of GPDs ready, some already tested and discarded (SamsungLabs)
-    - Reason: Picks on unusable poses e.g. below the object, and has no way of taking as input the characteristics of the gripper.
-- Advances on the placing object pipeline.
+**In Progress:**
 
-### Notes
-- Slow week but the @Home manipulation team is known for rising from the ashes like a phoenix.
+- CuRobo worked on PCs; Orin environment not ready.
+- Listed candidate GPDs; some tested and discarded (e.g. SamsungLabs — picks on unusable poses, ignores gripper geometry).
+- Placing-object pipeline advances.
+
+**Notes:** slow week; the @Home manipulation team is known for rising from the ashes like a phoenix.
 
 ## 2025-03-27
-This includes both weeks from 2025-03-07 to 2025-03-20
 
-### News
-- No news
+This entry covers both weeks from 2025-03-07 to 2025-03-20.
 
-### Done
-- Cleaned up task manager, got some remaining things ready for receptionist
-- Fixed an issue where collision objects were collising among themselves
-- Heatmap for getting place position
+**News:** first pick of the year.
 
-### In Progress
-- CuRobo worked on PCs, environment on the Orin is not ready yet.
-- List of GPDs ready, some already tested and discarded (SamsungLabs)
-    - Reason: Picks on unusable poses e.g. below the object, and has no way of taking as input the characteristics of the gripper.
-- Advances on the placing object pipeline.
+**Done:**
 
-### Notes
-- Slow week but the @Home manipulation team is known for rising from the ashes like a phoenix.
+- Successful tests on simulation and real life — zero sim-to-real code changes.
+- GPD connection to ROS 2.
+- 2D detection handler to ease use of 2D object detection.
+- Documentation on running pick & place methods and all nodes for Receptionist.
 
-## 2025-03-27
-This includes both weeks from 2025-03-07 to 2025-03-20
+![Pick on simulation](../../assets/development/manipulation/spotlights/spotlight_2025_03_27_pick.jpg)
 
-### News
-- First pick of the year
+**In Progress:**
 
-### Done
-- Succesful tests on simulation and real life ---> not a line of code modified on sim2real
-- GPD connection to ROS2
-- 2D Detection handler to ease use of 2d object detection
-- Documentation on running pick and place methods and all nodes necessary for receptionist
+- Next-phase planning: new motion planning methods, faster 3D perception, constrained planning, task-specific work.
+- Place methods and tests.
+- Acceleration of perception_3d.
+- Looking for new GPDs.
 
-Pick on Simulation:
+**Notes:**
 
-![image](../../assets/development/manipulation/spotlights/spotlight_2025_03_27_pick.jpg)
-
-### In Progress
-- Planning of the next phase of the project:
-    - New motion planning methods
-    - Accelerating 3D perception
-    - Constrained Planning
-    - Task-specific work
-- Place methods and tests 
-- Accelerating perception 3D methods
-- Looking for new GPDs
-
-### Notes
-- Our additions to the pick pipeline show a SIGNIFICANT improvement in planning time, from several minutes to less than 10 seconds. 
-- We will begin the SOTA phase to improve all areas of the pipeline:
-    - Faster Motion planning
-    - Optimized Motion Planning
-    - Better GPDs
-
----
+- Pick-pipeline additions show a significant improvement in planning time, from several minutes to under 10 seconds.
+- Starting the SOTA phase to improve every area of the pipeline.
 
 ## 2025-03-20
-This includes both weeks from 2025-03-07 to 2025-03-20
 
-### News
-- We got early results on the March 15th demo. 
+This entry covers both weeks from 2025-03-07 to 2025-03-20.
 
-### Done
-- Pick server, which handles all motion planning to pick objects
-- Manipulation Core, that communicates with detector, GPD and pick server
-- Manipulation Server, which communicates external systems e.g. task manager, with the manipulation core
-- Object detector 2D with 3D point extraction
-- Object 3D extraction -> Clustering and mesh reconstruction
-    - We added a new method to accelerate planning by reconstructing the table as a box and the object as a set of spheres instead of a mesh
-- Gazebo simulation and moveit config seem to be all ready to use
-- Octomap working now on ZED input
-- Pick using 3D object extraction and pick server
- 
-### In Progress
-- Grasping pose detection connection to ROS2
-- Service to handle updating recent detections to avoid subscribers on many nodes
-- Integration of detection and GPD on Manipulation Core
-- Planning of the next phase of the project:
-    - New motion planning methods
-    - Accelerating 3D perception
-    - Constrained Planning
-    - Task-specific work 
+**News:** early results on the March-15 demo.
 
-### Notes
-- Moveit2 seems to have no real benefits over Moveit1 apart from the constrained planning feature. We expect other changes, such as the primitive object reconstruction to solve old planning time issues.
-- All code so far has not been migrated to ROS2 from its version on home-manipulation, but reworked and replanned for better maintainability and flexibility.
+**Done:**
 
----
+- Pick server (motion planning to pick objects).
+- Manipulation Core (communicates with detector, GPD, and pick server).
+- Manipulation Server (external interface — task manager ↔ manipulation core).
+- 2D object detector with 3D point extraction.
+- 3D object extraction — clustering and mesh reconstruction. New method: reconstruct the table as a box and the object as a set of spheres instead of a mesh — accelerates planning.
+- Gazebo simulation and MoveIt config ready.
+- Octomap working on ZED input.
+- Pick using 3D object extraction + pick server.
+
+**In Progress:**
+
+- Grasp-pose detection ROS 2 connection.
+- Service to handle updating recent detections (avoid many subscribers).
+- Detection + GPD integration in Manipulation Core.
+- Next-phase planning (as above).
+
+**Notes:**
+
+- MoveIt 2 has no real benefits over MoveIt 1 except constrained planning. Primitive object reconstruction is expected to fix old planning-time issues.
+- Code so far has been reworked from scratch (not migrated from `home-manipulation`) for maintainability and flexibility.
 
 ## 2025-03-06
 
-### News
-- no news
+**Done:**
 
-### Done
-- Object Detector 2D working with 2D, no 3D yet
-- Refactored Motion Planning and Object Detector code
-- Dashgo moveit config working
-- Working gripper with xarm_api
-- Working Action Services and services for most motion planning tasks (plan, execute, collision objects)
-- Demo for scholarships (??)
- 
-### In Progress
-- Object 2D projection to 3D
-- Object 3D extraction -> Clustering and mesh reconstruction
-- Full pick pipeline tests
-- Grasping pose detection
-- Working octomap from zed input
-- Gazebo simulation 
+- 2D object detector working in 2D (no 3D yet).
+- Refactored motion planning and object-detector code.
+- DashGo MoveIt config working.
+- Gripper working with `xarm_api`.
+- Action servers and services for most motion-planning tasks (plan, execute, collision objects).
+- Demo for scholarships.
 
-### Notes
-- We seem to be on track for good results on March 15th :)
+**In Progress:**
 
----
+- 2D → 3D projection.
+- 3D object extraction (clustering and mesh reconstruction).
+- Full pick-pipeline tests.
+- Grasp-pose detection.
+- Octomap from ZED input.
+- Gazebo simulation.
+
+**Notes:** on track for good results on March 15.
 
 ## 2025-02-27
 
-### News
-- Welcoming new team member: Ricardo Guerrero
-- New team for the February-May period:
-    * Iván Romero Wells
-    * José Luis Dominguez
-    * David Vázquez
-    * Alexis Chapa
-    * Alejandro González
-    * Ricardo Guerrero
-    * Gerardo Fregoso
-    * Yair Reyes
-    * Emiliano Flores
+**News:** new team member — Ricardo Guerrero. Team for the Feb–May period (9 members, the largest so far): Iván Romero Wells, José Luis Domínguez, David Vázquez, Alexis Chapa, Alejandro González, Ricardo Guerrero, Gerardo Fregoso, Yair Reyes, Emiliano Flores.
 
-This is the largest team we have had so far, with 9 members.
+**Done:**
 
-### Done
-- Table/Surface extraction migrated
-- MoveIt2 interface on Python integrated within subtask manager
-### In Progress
-- Object 2D detection and extraction
-- Object 3D extraction -> Clustering and mesh reconstruction
-- Pick and Place server for motion planning
+- Table / surface extraction migrated.
+- MoveIt 2 interface in Python integrated within the subtask manager.
 
-### Notes
-- A pick and place demo has been scheduled for March 15th, which will mark the start of development into the next phase of the project, involving new motion planning methods and accelerating 3D perception.
-- A pick and place demo has been scheduled for March 15th, which will mark the start of develoomoent into the next phase of the project, involving new motion planning methods and accelerating 3D perception.
+**In Progress:**
+
+- 2D object detection and extraction.
+- 3D object extraction (clustering and mesh reconstruction).
+- Pick & Place server for motion planning.
+
+**Notes:** a pick & place demo is scheduled for March 15, marking the start of the next phase (new motion-planning methods, accelerated 3D perception).

--- a/docs/development/manipulation/tasks.md
+++ b/docs/development/manipulation/tasks.md
@@ -1,0 +1,398 @@
+---
+title: Running Tasks
+---
+
+# Running Tasks
+
+Practical guide to **launching** the manipulation stack and **sending** picks / places / pours. Everything below assumes you have already followed [Setup & Build](setup.md) and you are inside the manipulation container (`./run.sh manipulation`).
+
+!!! abstract "Quickstart"
+    1. `./run.sh vision` *(in another terminal)* — start vision so detections flow.
+    2. `./run.sh manipulation --ppc` — bring up MoveIt + the full pick/place stack.
+    3. Place an object on the table.
+    4. `ros2 run pick_and_place keyboard_input.py` — open the interactive picker.
+    5. Type the number of the detection or its label — the robot picks it.
+
+## Launch hierarchy
+
+There is one base launch for the arm + perception, and one for the pick/place stack. Every competition task is just a composition of those two.
+
+```mermaid
+graph TD
+    A[ros2 launch arm_pkg<br/>frida_moveit_config.launch.py] --> M[MoveIt + xArm driver + RViz + downsample]
+    B[ros2 launch pick_and_place<br/>pick_and_place.launch.py] --> S[pick / place / pour servers + perception_3d + heatmap + motion_planning]
+
+    G[manipulation_general/launch/&lt;task&gt;.launch.py] --> A
+    G --> B
+    G --> X[task-specific extras<br/>e.g. follow_face_node]
+```
+
+=== "Just the arm"
+
+    ```bash
+    ros2 launch arm_pkg frida_moveit_config.launch.py
+    ```
+
+=== "Pick stack only (MoveIt already up)"
+
+    ```bash
+    ros2 launch pick_and_place pick_and_place.launch.py
+    ```
+
+=== "Full task launch"
+
+    ```bash
+    ros2 launch manipulation_general gpsr.launch.py
+    ```
+
+### Most useful launch arguments
+
+#### `pick_and_place.launch.py`
+
+| Argument | Default | When to change |
+|---|---|---|
+| `use_sim_time` | `false` | Set `true` for MuJoCo (switches every node to `/clock`). |
+| `point_cloud_topic` | `/point_cloud` | Use `/filtered_cloud` in MuJoCo (the MoveIt self-filtered topic). |
+
+#### `frida_moveit_config.launch.py`
+
+| Argument | Default | Notes |
+|---|---|---|
+| `robot_ip` | `192.168.31.180` | Real arm IP. Change to your subnet. |
+| `show_rviz` | `true` | RViz config with planning scene + grasp markers. |
+| `clean_logs` | `true` | Sets `ROS_LOG_LEVEL=WARN` to hide MoveIt INFO spam. |
+| `add_gripper` | `false` | Set `true` only if using the UFactory gripper (we have our own). |
+| `kinematics_suffix` | `""` | Selects IK plugin variant (e.g. IKFast). |
+
+## From the host: `./run.sh` shortcuts
+
+Each competition task has a one-liner that enters the container and runs the right launch:
+
+```bash
+./run.sh manipulation --gpsr            # GPSR
+./run.sh manipulation --ppc             # Pick & Place Challenge
+./run.sh manipulation --restaurant      # Restaurant
+./run.sh manipulation --carry           # Carry My Luggage
+./run.sh manipulation --hric            # Human-Robot Interaction Challenge
+```
+
+Each maps to `ros2 launch manipulation_general <task>.launch.py` — see [`docker/manipulation/run.sh`](https://github.com/RoBorregos/home2/blob/main/docker/manipulation/run.sh) for the exact dispatch.
+
+## First pick — end to end
+
+!!! example "Walkthrough"
+    **1. Make sure vision is up** *(separate container — `./run.sh vision`)*. You need either:
+
+    - `/vision/detection_handler` service (for known objects), or
+    - `ZERO_SHOT_DETECTIONS_TOPIC` (for open-set detection).
+
+    **2. Bring up manipulation:**
+
+    ```bash
+    ros2 launch manipulation_general ppc.launch.py
+    ```
+
+    Wait until you see:
+
+    - `Manipulation Core has been started`
+    - `pick_server`, `place_server`, `pour_server` reporting ready
+    - `gpd_service` logging the loaded GPD config
+
+    **3. Place an object** on the table in front of the robot, between 0.4 m and 1.0 m.
+
+    **4. In a new terminal in the same container**, run the interactive shell:
+
+    ```bash
+    ros2 run pick_and_place keyboard_input.py
+    ```
+
+    **5. Select an object** from the list (or type a label not yet detected — it will be sent regardless).
+
+If you do not have vision, see [Picking without vision](#picking-without-vision).
+
+## Interactive keyboard tool { #interactive-keyboard-tool }
+
+`keyboard_input.py` is the standard developer interface to the manipulation server. It subscribes to detections, prints a menu, and sends `ManipulationAction` goals.
+
+Example output:
+
+```
+Available objects:
+1. bottle
+2. cup
+3. fork
+-2. Refresh objects list
+-3. Place
+-4. Place on shelf
+-5. Place on shelf (with plane height)
+-6. Pour
+-7. Place on clicked point
+-8. Place closeto
+-9. Special Request Place
+-10. Pour (object already grasped)
+-11. Pick from shelf (keep octomap)
+q. Quit
+```
+
+### Menu reference
+
+| Choice | Action | Maps to |
+|---|---|---|
+| `1..N` | Pick the *N*-th listed detection. | `ManipulationTask.PICK` |
+| _free text_ | Pick by exact label (even if not yet detected). | `ManipulationTask.PICK` |
+| `-2` | Refresh detections (subscribes for 1 s). | — |
+| `-3` | Place — heatmap chooses the spot. | `ManipulationTask.PLACE` |
+| `-4` | Place on shelf — keeps the octomap, `is_shelf=True`. | `ManipulationTask.PLACE` |
+| `-5` | Place on shelf at a specific height. | `place_params.table_height` + `table_height_tolerance` |
+| `-6` | Pour — type the object name and bowl name. | `ManipulationTask.POUR` |
+| `-7` | Place at an RViz "Publish Point" click. | `place_params.forced_pose` |
+| `-8` | Place close to another known object. | `place_params.close_to` |
+| `-9` | Special-request place — `close` / `front` / `back` / `left` / `right`. | `place_params.special_request` (JSON) |
+| `-10` | Pour with `object_already_grasped=True`. | `pour_params.object_already_grasped` |
+| `-11` | Pick from a shelf (scans the environment first). | `scan_environment=True` |
+
+### Distance filter
+
+```bash
+ros2 run pick_and_place keyboard_input.py \
+    --ros-args -p min_distance:=0.0 -p max_distance:=1.5
+```
+
+Detections outside `[min_distance, max_distance]` (in meters, distance to arm base) are dropped before listing.
+
+## Picking from code
+
+The minimal contract is: build a `ManipulationAction.Goal`, send it, await the result.
+
+```python
+import rclpy
+from rclpy.node import Node
+from rclpy.action import ActionClient
+from frida_interfaces.action import ManipulationAction
+from frida_interfaces.msg import ManipulationTask
+from frida_constants.manipulation_constants import MANIPULATION_ACTION_SERVER
+
+
+class MyTask(Node):
+    def __init__(self):
+        super().__init__("my_task")
+        self.client = ActionClient(self, ManipulationAction, MANIPULATION_ACTION_SERVER)
+
+    def pick(self, label: str, scan_env: bool = False):
+        goal = ManipulationAction.Goal()
+        goal.task_type = ManipulationTask.PICK
+        goal.pick_params.object_name = label
+        goal.pick_params.min_distance = 0.0
+        goal.pick_params.max_distance = 1.5
+        goal.scan_environment = scan_env
+        self.client.wait_for_server()
+        return self.client.send_goal_async(goal)
+```
+
+For `PLACE`, set `goal.task_type = ManipulationTask.PLACE` and fill `goal.place_params`. For `POUR`, fill `goal.pour_params` (`object_name`, `bowl_name`, optional `object_already_grasped`).
+
+!!! example "Complete reference client"
+    [`pick_and_place/tests/call_pick_action.py`](https://github.com/RoBorregos/home2/blob/main/manipulation/packages/pick_and_place/pick_and_place/tests/call_pick_action.py).
+
+## Lower-level motion calls
+
+Sometimes you only want to move the arm — no perception, no grasp planning. Use `motion_planning_server` directly.
+
+=== "Joint goal — by name"
+
+    Easiest path, using the Python helper:
+
+    ```python
+    from frida_motion_planning.utils.service_utils import move_joint_positions
+
+    move_joint_positions(
+        move_joints_action_client=self._move_joints_client,
+        named_position="table_stare",   # see xarm_configurations.py
+        velocity=0.3,
+    )
+    ```
+
+=== "Joint goal — numeric"
+
+    ```python
+    from frida_interfaces.action import MoveJoints
+    from frida_constants.manipulation_constants import DEG2RAD
+
+    goal = MoveJoints.Goal()
+    goal.joint_positions = [j * DEG2RAD for j in [-90, -45, -90, 0, 0, 45]]  # FRONT_STARE
+    goal.velocity = 0.3
+    ```
+
+    !!! warning
+        `MoveJoints.action` has no `named_position` field. Name lookup happens in the
+        Python helper before sending the goal.
+
+=== "Pose goal"
+
+    ```python
+    from frida_interfaces.action import MoveToPose
+    from geometry_msgs.msg import PoseStamped
+
+    goal = MoveToPose.Goal()
+    goal.pose.header.frame_id = "link_base"
+    goal.pose.pose.position.x = 0.4
+    goal.pose.pose.position.y = 0.0
+    goal.pose.pose.position.z = 0.3
+    goal.pose.pose.orientation.w = 1.0
+    goal.velocity = 0.2
+    goal.target_link = "link_eef"      # or gripper_grasp_frame
+    goal.planner_id = ""               # let server pick (RRTConnect)
+    ```
+
+    Working example: [`call_pose_goal.py`](https://github.com/RoBorregos/home2/blob/main/manipulation/packages/frida_motion_planning/examples/call_pose_goal.py).
+
+=== "Gripper"
+
+    ```python
+    from frida_motion_planning.utils.service_utils import close_gripper, open_gripper
+
+    close_gripper(client)   # SetBool data=True
+    open_gripper(client)    # SetBool data=False
+    ```
+
+    Service: `/manipulation/gripper/set_state`. Booleans only — the gripper has no force control. `pick_server` detects contact via joint effort in mode 5.
+
+### Named joint configurations
+
+Defined in `frida_constants/xarm_configurations.py`. Use by name with `move_joint_positions(named_position="...")`.
+
+| Name | Purpose |
+|---|---|
+| `FRONT_STARE` | Default front-facing pose (HRI, GPSR resting). |
+| `FRONT_LOW_STARE` | Slightly downward — receptionist, presenting. |
+| `TABLE_STARE` | Looks at the table — pick start pose. |
+| `CUTLERY_STARE` | Closer look at the table — pre-cutlery pick. |
+| `PICK_STARE_AT_TABLE` | Alternative to `TABLE_STARE` for taller surfaces. |
+| `NAV_POSE` | Compact pose while navigating. |
+| `NAV_CARRY_BAG_POSE` | Compact pose while carrying a bag. |
+| `CARRY_POSE` | Holding a bag/object for delivery. |
+| `RECEIVE_OBJECT` | Posture for an HRI handover from a person. |
+| `HAND_BAG_POSE` | Searching for a hand to give a bag to. |
+| `PLACE_FLOOR_LEFT`, `PLACE_FLOOR_RIGHT` | Placing a bag on the floor. |
+| `SCAN_FLOOR_CARRY_BAG_POSE` | Scanning low for a bag during carry. |
+
+## Picking without vision { #picking-without-vision }
+
+`manipulation_client.py` listens to `/clicked_point` (RViz "Publish Point" tool) and forwards it as a pick request:
+
+```bash
+ros2 run pick_and_place manipulation_client.py
+```
+
+Click the cluster in RViz → the server treats that as the object centroid → perception + GPD run from there → motion. Useful when vision is down or you are testing perception and motion in isolation.
+
+## Picking cutlery (forks, knives, spoons)
+
+Cutlery uses a different sub-pipeline. **No special flag** — if the requested `object_name` is in `CUTLERY_NAMES = ["fork", "knife", "spoon", "cutlery"]`, `PickManager` automatically takes the cutlery path:
+
+1. Move to `cutlery_stare`.
+2. Subscribe to `/manipulation/flat_grasp_pose` (`flat_grasp_estimator.py`, top-down PCA-aligned grasp).
+3. Average 10+ samples for Z stability.
+4. Send the averaged pose to `pick_server`.
+5. **Force-guarded descent**: xArm enters mode 5, descends at `CUTLERY_DESCENT_SPEED = 20 mm/s`, aborts when joint effort exceeds `CUTLERY_EFFORT_THRESHOLD = 6.5 N`.
+
+??? abstract "Tuning knobs (`pick_server.py`)"
+
+    ```python
+    CUTLERY_DESCENT_SPEED        = 20.0   # mm/s
+    CUTLERY_EFFORT_THRESHOLD     = 6.5    # N
+    CUTLERY_DESCENT_TIMEOUT      = 10.0   # s
+    CUTLERY_PRE_GRASP_HEIGHT     = 0.15   # m
+    CUTLERY_EFFORT_GRACE_PERIOD  = 0.5    # s (ignore initial spike)
+    CUTLERY_POST_CONTACT_RETRACT = 0.002  # m
+    ```
+
+    - **Hits too hard?** Raise `CUTLERY_PRE_GRASP_HEIGHT` or lower `CUTLERY_EFFORT_THRESHOLD`.
+    - **Stops before touching?** Raise the threshold.
+
+## Picking from a shelf
+
+Use `goal.scan_environment = True` (option `-11` in the keyboard tool). This:
+
+1. **Skips** the `clear_octomap` call.
+2. Sweeps `joint1` by `±SCAN_ANGLE_HORIZONTAL` and `joint5` by `±SCAN_ANGLE_VERTICAL` to build the octomap of the shelf.
+3. Runs the normal pick pipeline with the octomap intact.
+
+Returned grasp will be horizontal if the object pose suggests it (taller than wider).
+
+## Placing — `place_params` field reference
+
+| Field | Meaning |
+|---|---|
+| `is_shelf` | If true, keep the octomap and don't go to `table_stare` first. |
+| `table_height`, `table_height_tolerance` | Override the detected plane height (meters). Useful for fixed shelves. |
+| `close_to` | A known object label — the heatmap will bias the place point near it. |
+| `special_request` | JSON, e.g. `{"request":"close_by","object":"box","position":"left"}`. |
+| `forced_pose` | Skip the heatmap entirely and use this pose. |
+
+The heatmap result is published on `/manipulation/table_place_point_debug`. The corresponding place EE pose lands on `/manipulator/place_ee_link_pose`. **Visualise both** in RViz before debugging the planner.
+
+## Pouring
+
+Two modes:
+
+=== "Pick then pour (default)"
+
+    `object_already_grasped=False`. The server picks the source object first, then pours into the bowl, then keeps it attached for a follow-up place.
+
+=== "Already grasped"
+
+    `object_already_grasped=True`. Skips the pick — useful when chained from a previous `PICK`.
+
+!!! info "Upright-pick objects"
+    The source object must be in `POUR_OBJECT_NAMES = {"blue_cereal_box", "cereal", "chocomilk_box", "milk"}` to be picked **upright** instead of with GPD's best guess.
+
+## Diagnostic commands
+
+```bash
+# List the action servers and their states
+ros2 action list -t
+ros2 action info /manipulation/manipulation_action_server
+
+# Watch goal feedback
+ros2 topic echo /manipulation/manipulation_action_server/_action/feedback
+
+# Force-clear the octomap
+ros2 service call /clear_octomap std_srvs/srv/Empty
+
+# Move the arm to a joint goal (joints in radians)
+ros2 action send_goal /manipulation/move_joints_action_server frida_interfaces/action/MoveJoints \
+  "{joint_positions: [-1.57, -0.78, -1.57, 0.0, 0.0, 0.78], joint_names: [], velocity: 0.3, acceleration: 0.0}"
+
+# Open / close gripper
+ros2 service call /manipulation/gripper/set_state std_srvs/srv/SetBool "{data: false}"   # open
+ros2 service call /manipulation/gripper/set_state std_srvs/srv/SetBool "{data: true}"    # close
+```
+
+## Debugging recipe
+
+When something goes wrong, walk through this checklist before diving into logs:
+
+??? question "Did the action even arrive?"
+    `ros2 action info /manipulation/manipulation_action_server` should show your client. If not, you probably imported the wrong constant — make sure you used `MANIPULATION_ACTION_SERVER` from `frida_constants`.
+
+??? question "Is perception failing?"
+    Watch `/manipulation/table_place_point_debug` and the cluster extraction logs. If the cluster is wrong, look at `add_primitives.cpp` parameters. If the plane is tilted, look at `remove_plane.cpp`.
+
+??? question "GPD returns nothing?"
+    Confirm `gpd_service` is alive (`ros2 node list | grep gpd`). Verify the configured `.cfg` path — the **testing** cfg has higher rejection. Check `/gpd_service` logs for the score distribution.
+
+??? question "MoveIt fails to plan?"
+    The octomap may be polluted by a stale cloud. Clear it:
+
+    ```bash
+    ros2 service call /clear_octomap std_srvs/srv/Empty
+    ```
+
+??? question "Pick succeeds but lift fails?"
+    The attached collision object overlaps the world. Confirm in RViz that the attached primitive size is correct. If too big, tune `add_primitives.cpp`.
+
+??? question "Place places nowhere or always at the same point?"
+    The heatmap input cloud is probably not in `base_link`. Check the frame_id on the cloud topic.
+
+For the canonical list of issues over the past months, browse [Spotlights](spotlights.md).

--- a/docs/years/.pages
+++ b/docs/years/.pages
@@ -1,5 +1,6 @@
 title: Advances over the years
 nav:
+    - "2026"
     - "2025"
     - "2024"
     - "2023"

--- a/docs/years/2026/Manipulation/index.md
+++ b/docs/years/2026/Manipulation/index.md
@@ -1,0 +1,163 @@
+---
+title: Manipulation 2026
+---
+
+# Manipulation — 2026
+
+The 2026 cycle focused on **closing the loop** on the pick-&-place pipeline that landed at TMR 2025 and extending it toward the new RoboCup tasks: HRIC handovers, restaurant service, cutlery handling, and full simulation parity. Most of the work happened on top of the existing `pick_and_place` stack and the new MuJoCo simulation environment, with the introduction of **IKFast** as the default analytical IK solver.
+
+This year also marked the first appearance of a dedicated **Pick-&-Place Task Manager**, decoupling the manipulation pipeline from the per-task state machines.
+
+!!! info "Scope of this page"
+    Everything listed below has been **merged into `main` of `home2`**. VAMP / `foam` / `cricket` work was explored on a feature branch during the cycle but is **not** part of the merged code, so it is not documented here.
+
+!!! tip "Where to go next"
+    - **Engineering reference** (how to run things, packages, APIs) → [Manipulation development docs](../../../development/manipulation/overview.md).
+    - **Week-by-week development log** → [Spotlights](../../../development/manipulation/spotlights.md).
+
+## Headlines
+
+<div class="grid cards" markdown>
+
+-   :material-routes:{ .lg .middle } **Motion planning**
+
+    ---
+
+    IKFast plugin shipped as the default kinematics solver
+    ([#856](https://github.com/RoBorregos/home2/pull/856)). `xarm_ros2`
+    submodule pinned to `roborregos_custom` with services enabled
+    ([#729](https://github.com/RoBorregos/home2/pull/729)).
+
+-   :material-hand-back-right:{ .lg .middle } **Pick & Place pipeline**
+
+    ---
+
+    Cutlery picks via force-guarded descent. Gripper grasp-feedback
+    integration. Distance filter on detections. Place-on-top, place-on-floor,
+    dishwasher placement, directional places.
+
+-   :material-account-multiple:{ .lg .middle } **HRI support**
+
+    ---
+
+    `GoToHand` action server for handovers. Move-to-point integrated into
+    HRIC. Bag-pose search while navigating.
+
+-   :material-cube-outline:{ .lg .middle } **3D perception**
+
+    ---
+
+    Plane-rotation fix. Variable-resolution voxelization + parallel
+    filtering. Research on transparent-object grasping (ClearGrasp / ASGrasp).
+
+-   :material-robot-industrial:{ .lg .middle } **Simulation**
+
+    ---
+
+    MuJoCo + `ros2_control` parity end-to-end. Gripper fix. Receptionist
+    scene. Point-cloud round-trip validated.
+
+-   :material-book-open-page-variant:{ .lg .middle } **Documentation**
+
+    ---
+
+    TDP 2026 reviewed. New development docs (this site) authored. Repo
+    cleanup on Orin; CI green on CPU, CUDA, and L4T.
+
+</div>
+
+## Breakdown by area
+
+### :material-routes: Motion planning
+
+- **Analytical IK for xArm 6 (IKFast)** — added the `xarm6_ikfast_plugin` package and made it the kinematics solver for MoveIt. Significantly reduces IK time inside the pick planner. ([#856](https://github.com/RoBorregos/home2/pull/856))
+- **`xarm_ros2` submodule fix** — pinned to the `roborregos_custom` branch with the services we depend on enabled. ([#729](https://github.com/RoBorregos/home2/pull/729))
+
+### :material-hand-back-right: Pick & Place pipeline
+
+- **Pick cutlery (force-guarded descent)** — new code path for forks, knives, and spoons. The arm enters xArm mode 5 and descends at ~20 mm/s; `flat_grasp_estimator.py` provides a top-down PCA-aligned grasp pose, and the pick aborts on a joint-effort threshold so the gripper doesn't slam the table. ([#797](https://github.com/RoBorregos/home2/pull/797))
+- **Improved picks** — pre-grasp logic and approach-axis offsets, addressing the long-standing "picks too low / collides with table" issue. ([#832](https://github.com/RoBorregos/home2/pull/832))
+- **`EEF_CONTACT_LINKS` update** — extended the allowed contact-link list to cover the gripper and finger geometry so MoveIt's collision check stops false-positiving on grasp contact. ([#833](https://github.com/RoBorregos/home2/pull/833))
+- **Grasp feedback from the custom gripper** — renamed `ir_gripper` → `grasp_detector` and exposed the on-board grasp-detection signal via TGPIO so the pipeline can read whether the gripper actually holds something. ([#850](https://github.com/RoBorregos/home2/pull/850))
+- **Distance mask for picks** — vision detections are filtered by `min_distance` / `max_distance` (`pick_params`) before being considered, so the robot never tries to pick objects clearly out of reach. ([#659](https://github.com/RoBorregos/home2/pull/659))
+- **Place bag on the floor** — dedicated place pipeline for the carry task. ([#696](https://github.com/RoBorregos/home2/pull/696))
+- **Pour refactor — object already grasped** — `PourMotion` no longer re-picks when the source object is already in the gripper, enabling chained pick → pour → place sequences. ([#828](https://github.com/RoBorregos/home2/pull/828))
+- **Pick plane removal** — refined how the supporting plane interacts with the pick collision model; padding-scale adjustments. ([#974](https://github.com/RoBorregos/home2/pull/974))
+
+### :material-account-multiple: Task-manager layer (new)
+
+- **Pick-&-Place Challenge node** — initial cut of the standalone PPC task manager. ([#851](https://github.com/RoBorregos/home2/pull/851))
+- **PPC TMR 2026** — challenge-specific updates and integration. ([#918](https://github.com/RoBorregos/home2/pull/918))
+
+### :material-hand-okay: Human-Robot Interaction support
+
+- **`GoToHand` action for HRIC handover** — vision publishes a `PointStamped` for the user's hand; `pick_server` exposes `go_to_hand_action_server` and brings the EE within `hand_offset` (default 10 cm) of the point along the approach axis. ([#724](https://github.com/RoBorregos/home2/pull/724))
+- **HRIC integration touching the manipulation side** — motion planning server, `MoveItPlanner`, `pick_server`, and `hric.launch.py` updates. ([#778](https://github.com/RoBorregos/home2/pull/778), [#680](https://github.com/RoBorregos/home2/pull/680))
+- **Hand-detection debug fixes**. ([#879](https://github.com/RoBorregos/home2/pull/879))
+- **Named configurations for carry** — `FRONT_STARE_CARRY_BAG` ([#866](https://github.com/RoBorregos/home2/pull/866)) and `NAV_CARRY_BAG_POSE` ([#864](https://github.com/RoBorregos/home2/pull/864)) joint configurations.
+
+### :material-cube-outline: 3D perception
+
+The 3D-perception nodes in main (`perception_3d/`) were tuned during the cycle (RANSAC distance threshold 0.03 m, Euclidean cluster tolerance 0.04 m, voxel leaves 0.01/0.10 m). Larger restructuring of the perception stack (transparent-object handling, ClearGrasp/ASGrasp research, etc.) was discussed in the spotlights but not merged to `main` during the documented cycle.
+
+### :material-robot-industrial: Simulation
+
+- **MuJoCo integration** — `mujoco_ros2_control` plugin pinned, base-link mesh decimated, camera and joint actuators wired, `mujoco_spawn` package introduced. ([#739](https://github.com/RoBorregos/home2/pull/739))
+- **Simulation scene** — load house, decompose its collision geometry, replace fixtures with an object pool. ([#922](https://github.com/RoBorregos/home2/pull/922))
+- **`mujoco_spawn` cleanup** — drop vision nodes from the sim launch so the pick stack runs against a clean perception input. ([#923](https://github.com/RoBorregos/home2/pull/923))
+- **Simulation container** — dedicated MuJoCo image and entrypoints. ([#928](https://github.com/RoBorregos/home2/pull/928))
+- **Simulation fixes** + **regression hotfix** — final stabilisation passes. ([#966](https://github.com/RoBorregos/home2/pull/966), [#973](https://github.com/RoBorregos/home2/pull/973))
+
+### :material-book-open-page-variant: Documentation & infrastructure
+
+- **Build alias updated** to keep `colcon build` working as the workspace grew. ([#795](https://github.com/RoBorregos/home2/pull/795))
+- **Manipulation development docs** (this site) — the [overview](../../../development/manipulation/overview.md), [setup](../../../development/manipulation/setup.md), [architecture](../../../development/manipulation/architecture.md), [packages](../../../development/manipulation/packages.md), [tasks](../../../development/manipulation/tasks.md), and [interfaces](../../../development/manipulation/interfaces.md) pages were authored this cycle (this repo, not `home2`).
+
+## Tasks covered
+
+| Competition task | Launch | Manipulation features used |
+|---|---|---|
+| **PPC** (Pick & Place Challenge) | `manipulation_general/launch/ppc.launch.py` | Full pick+place stack, no extras |
+| **GPSR** | `gpsr.launch.py` | Full pick+place stack + `follow_face_node` |
+| **Restaurant** | `restaurant.launch.py` | Pick+place + face follow + cutlery support |
+| **HRIC** | `hric.launch.py` | `GoToHand`, move-to-point, face follow |
+| **Carry My Luggage** | `carry.launch.py` | MoveIt + motion planning + nav-friendly downsampler. The Carry TM brings up pick/place nodes separately when needed. |
+| **Receptionist** | `receptionist.launch.py` | MoveIt + motion planning + face follow. **No pick stack.** |
+| **Storing Groceries / Dishwasher** | (per-task TMs) | Shelf scanning + dishwasher placement |
+| **Trash throwing** | (subtask) | Place-on-top + heatmap centroid mode |
+
+## Contributions on `main`
+
+The table below reflects only the work **merged into `main` of `home2`** during the 2026 cycle (Jan–May 2026). Each entry links to the originating PR.
+
+| Member | Merged contributions |
+|---|---|
+| **José Luis Domínguez Morales** | [#696 Place bag](https://github.com/RoBorregos/home2/pull/696) · [#729 Pin `xarm_ros2` to `roborregos_custom`](https://github.com/RoBorregos/home2/pull/729) · [#795 Update build command](https://github.com/RoBorregos/home2/pull/795) · [#797 Pick cutlery](https://github.com/RoBorregos/home2/pull/797) · [#828 Pour refactor](https://github.com/RoBorregos/home2/pull/828) · [#832 Improve pick](https://github.com/RoBorregos/home2/pull/832) · [#833 Update `EEF_CONTACT_LINKS`](https://github.com/RoBorregos/home2/pull/833) · [#850 Rename `ir_gripper` → `grasp_detector` (TGPIO grasp feedback)](https://github.com/RoBorregos/home2/pull/850) · [#851 Pick & Place Challenge](https://github.com/RoBorregos/home2/pull/851) · [#856 IKFast analytical IK plugin for xArm 6](https://github.com/RoBorregos/home2/pull/856) · [#864 `NAV_CARRY_BAG_POSE`](https://github.com/RoBorregos/home2/pull/864) · [#866 `FRONT_STARE_CARRY_BAG`](https://github.com/RoBorregos/home2/pull/866) · [#918 PPC TMR 2026](https://github.com/RoBorregos/home2/pull/918) · [#922 Sim scene: load house + object pool](https://github.com/RoBorregos/home2/pull/922) · [#923 `mujoco_spawn`: drop vision nodes](https://github.com/RoBorregos/home2/pull/923) · [#928 Simulation container](https://github.com/RoBorregos/home2/pull/928) · [#966 Simulation fixes](https://github.com/RoBorregos/home2/pull/966) · [#973 Restore real-robot pick after MuJoCo regression](https://github.com/RoBorregos/home2/pull/973) |
+| **Fernando Hernandez Cantu** | [#659 Distance mask on `PickParams`](https://github.com/RoBorregos/home2/pull/659) · [#724 `GoToHand` action for HRIC handover](https://github.com/RoBorregos/home2/pull/724) · [#879 Hand-detection debug fixes](https://github.com/RoBorregos/home2/pull/879) · [#974 Remove pick plane (padding scale)](https://github.com/RoBorregos/home2/pull/974) |
+| **Efrain Vázquez** | [#739 MuJoCo simulation: `mujoco_ros2_control` integration, `mujoco_spawn`, base-link decimation, camera + actuators](https://github.com/RoBorregos/home2/pull/739) |
+| **Oscar Arreola** | [#778 HRIC March 17: motion planning, `MoveItPlanner`, `pick_server`, and `hric.launch.py` updates](https://github.com/RoBorregos/home2/pull/778) |
+| **Gilberto Malagamba Montejo** | [#680 Preliminary HRI Challenge (touches `hric.launch.py`)](https://github.com/RoBorregos/home2/pull/680) · [#810 HRIC testing — updates to `xarm_configurations.py`](https://github.com/RoBorregos/home2/pull/810) |
+| **Angela Camila Tite Haro** | [#880 Restaurant launch entry + radial sampling adaptive goal](https://github.com/RoBorregos/home2/pull/880) |
+
+!!! info "How this table was compiled"
+    From the output of:
+
+    ```bash
+    git log --since="2026-01-01" --pretty=format:"%h %an %s" -- \
+        manipulation/ \
+        frida_interfaces/manipulation/ \
+        frida_constants/frida_constants/manipulation_constants.py \
+        frida_constants/frida_constants/xarm_configurations.py
+    ```
+
+    Only commits that land manipulation-side code in `main` are listed. Documentation work, research, paper writing, and in-progress branches are intentionally **not** included — they live in the [Spotlights](../../../development/manipulation/spotlights.md) log instead.
+
+## Work explored but not in `main`
+
+The following appeared in the spotlights as in-progress or "Done" entries but **did not land in `main`** during the documented cycle:
+
+- **VAMP integration** (`vamp` / `foam` / `cricket` packages, planning fallback). Lives on a feature branch.
+- **Transparent-object grasping** research (ClearGrasp / ASGrasp / VPG).
+- Broader perception refactors and dense-cloud database for the grasp detector.
+
+See [Spotlights](../../../development/manipulation/spotlights.md) for the development log of each.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,10 +28,26 @@ markdown_extensions:
       anchor_linenums: true
   - pymdownx.inlinehilite
   - pymdownx.snippets
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.arithmatex:
       generic: true
+  - pymdownx.details
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - admonition
   - attr_list
+  - md_in_html
+  - tables
+  - footnotes
 
 validation:
   links:
@@ -42,6 +58,7 @@ plugins:
   - awesome-pages
 
 extra_javascript:
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  # polyfill.io was decommissioned in 2024 — removed to stop ERR_NAME_NOT_RESOLVED.
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
   - assets/javascripts/scroll-unlock.js
+  - assets/javascripts/mermaid-init.js

--- a/scripts/verify_mermaid_lightbox.py
+++ b/scripts/verify_mermaid_lightbox.py
@@ -1,18 +1,32 @@
 """End-to-end verification of the Mermaid badge + lightbox.
 
-Material puts the rendered SVG inside a CLOSED shadow root attached
-to <div class="mermaid">. Our JS:
-  1. Wraps each .mermaid div + a badge in a sibling-based .rb-mermaid-wrap
-  2. On click, MOVES the .mermaid div into the lightbox stage
-  3. On close, moves it back into its placeholder
+This is a MANUAL verification script — it is intentionally not under
+tests/ because it requires playwright + chromium (~150 MB) which we do
+not want to install in CI.
 
-So the verification is:
-  * After Material renders, .mermaid divs have non-zero size (shadow OK)
-  * Each .mermaid is wrapped in .rb-mermaid-wrap with a badge sibling
-  * Click badge → lightbox opens, .mermaid moves into stage,
-    placeholder takes its place in the article
-  * Wheel scroll transforms the moved .mermaid
-  * Escape closes, moves diagram back
+How to run it:
+
+  # one-time setup
+  python3 -m venv /tmp/rb-pw
+  /tmp/rb-pw/bin/pip install playwright
+  /tmp/rb-pw/bin/playwright install chromium
+
+  # in one terminal:
+  mkdocs serve --dev-addr 127.0.0.1:8765 --no-livereload
+
+  # in another:
+  /tmp/rb-pw/bin/python scripts/verify_mermaid_lightbox.py
+
+The script asserts that:
+  * After Material renders, .mermaid divs have non-zero size (shadow OK).
+  * Each .mermaid is wrapped in .rb-mermaid-wrap with a badge sibling.
+  * Click badge → lightbox opens, .mermaid moves into stage, placeholder
+    takes its place in the article.
+  * Wheel scroll transforms the moved .mermaid.
+  * Escape closes, moves diagram back.
+
+Screenshots of the open + zoomed lightbox are saved to
+/tmp/rb-mermaid-screens/ for visual review.
 """
 import sys
 from pathlib import Path

--- a/tests/test_mermaid_lightbox.py
+++ b/tests/test_mermaid_lightbox.py
@@ -143,6 +143,9 @@ def run() -> int:
               ov.dispatchEvent(new WheelEvent('wheel', { deltaY: -200, bubbles: true, cancelable: true }));
             }"""
         )
+        # RAF-batched write — wait one animation frame for the transform
+        # to be flushed to the DOM.
+        page.wait_for_timeout(50)
         post = page.evaluate(
             "() => { var el = document.querySelector('#rb-mermaid-lightbox .rb-lb-stage div.mermaid');"
             "        return el ? el.style.transform : null; }"

--- a/tests/test_mermaid_lightbox.py
+++ b/tests/test_mermaid_lightbox.py
@@ -1,0 +1,187 @@
+"""End-to-end verification of the Mermaid badge + lightbox.
+
+Material puts the rendered SVG inside a CLOSED shadow root attached
+to <div class="mermaid">. Our JS:
+  1. Wraps each .mermaid div + a badge in a sibling-based .rb-mermaid-wrap
+  2. On click, MOVES the .mermaid div into the lightbox stage
+  3. On close, moves it back into its placeholder
+
+So the verification is:
+  * After Material renders, .mermaid divs have non-zero size (shadow OK)
+  * Each .mermaid is wrapped in .rb-mermaid-wrap with a badge sibling
+  * Click badge → lightbox opens, .mermaid moves into stage,
+    placeholder takes its place in the article
+  * Wheel scroll transforms the moved .mermaid
+  * Escape closes, moves diagram back
+"""
+import sys
+from pathlib import Path
+from playwright.sync_api import sync_playwright
+
+URL = "http://127.0.0.1:8765/development/manipulation/architecture/"
+SHOTS = Path("/tmp/rb-mermaid-screens")
+SHOTS.mkdir(exist_ok=True)
+
+
+def log(ok: bool, msg: str) -> None:
+    print(f"  [{'OK  ' if ok else 'FAIL'}] {msg}")
+
+
+def run() -> int:
+    failures = 0
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        ctx = browser.new_context(viewport={"width": 1400, "height": 900})
+        page = ctx.new_page()
+        page.on("console", lambda m: print(f"  [console.{m.type}] {m.text}") if "rb-mermaid" in m.text or m.type == "error" else None)
+        page.on("pageerror", lambda e: print(f"  [PAGEERR] {e}"))
+
+        print("\n=== 1. Load page ===")
+        page.goto(URL, wait_until="networkidle", timeout=30_000)
+        log(True, f"loaded {URL}")
+
+        print("\n=== 2. Wait for Material's mermaid render (div has size) ===")
+        try:
+            page.wait_for_function(
+                """() => {
+                  const els = document.querySelectorAll('div.mermaid');
+                  return els.length > 0 &&
+                    Array.from(els).every(e => e.clientHeight > 0 || e.clientWidth > 0);
+                }""",
+                timeout=25_000,
+            )
+            sizes = page.evaluate(
+                "Array.from(document.querySelectorAll('div.mermaid'))"
+                ".map(e => ({w: e.clientWidth, h: e.clientHeight}))"
+            )
+            log(True, f"4 diagrams rendered: {sizes}")
+        except Exception as e:
+            failures += 1
+            log(False, f"diagrams never got dimensions: {e}")
+            sizes = page.evaluate(
+                "Array.from(document.querySelectorAll('div.mermaid'))"
+                ".map(e => ({w: e.clientWidth, h: e.clientHeight, html_len: e.innerHTML.length}))"
+            )
+            print(f"        sizes: {sizes}")
+
+        print("\n=== 3. Each diagram is wrapped + has a badge sibling ===")
+        wrap_info = page.evaluate(
+            """() => Array.from(document.querySelectorAll('div.mermaid')).map(e => ({
+              parent_is_wrap: e.parentElement && e.parentElement.classList.contains('rb-mermaid-wrap'),
+              wrap_has_badge: !!(e.parentElement && e.parentElement.querySelector(':scope > .rb-zoom-badge')),
+            }))"""
+        )
+        for i, info in enumerate(wrap_info):
+            ok = info["parent_is_wrap"] and info["wrap_has_badge"]
+            if not ok: failures += 1
+            log(ok, f"diagram #{i}: wrapped={info['parent_is_wrap']} has_badge={info['wrap_has_badge']}")
+
+        print("\n=== 4. Click first badge → lightbox opens ===")
+        try:
+            page.locator(".rb-zoom-badge").first.click(timeout=5_000)
+            log(True, "click dispatched")
+        except Exception as e:
+            failures += 1
+            log(False, f"badge click failed: {e}")
+            browser.close()
+            return failures
+
+        try:
+            page.wait_for_selector("#rb-mermaid-lightbox.rb-lb-open", timeout=2_000)
+            log(True, "lightbox opened")
+        except Exception as e:
+            failures += 1
+            log(False, f"lightbox did not open: {e}")
+
+        # After requestAnimationFrame the initial fit-scale is applied.
+        page.wait_for_timeout(200)
+        state = page.evaluate(
+            """() => {
+              const ov = document.getElementById('rb-mermaid-lightbox');
+              const stage = ov.querySelector('.rb-lb-stage');
+              const moved = stage.querySelector('div.mermaid');
+              const placeholder = document.querySelector('.rb-mermaid-placeholder');
+              const r = moved ? moved.getBoundingClientRect() : null;
+              return {
+                open: ov.classList.contains('rb-lb-open'),
+                display: getComputedStyle(ov).display,
+                stage_has_mermaid_div: !!moved,
+                // After transform: scale() the rendered (post-transform)
+                // box is much larger than clientWidth/clientHeight.
+                moved_rendered_size: r ? {w: Math.round(r.width), h: Math.round(r.height)} : null,
+                moved_intrinsic: moved ? {w: moved.clientWidth, h: moved.clientHeight} : null,
+                moved_transform: moved ? moved.style.transform : null,
+                placeholder_exists: !!placeholder,
+                article_no_longer_has_moved_div: document.querySelector('.md-content article div.mermaid') === null,
+              };
+            }"""
+        )
+        moved_w = state.get("moved_rendered_size", {}).get("w", 0) if state.get("moved_rendered_size") else 0
+        moved_h = state.get("moved_rendered_size", {}).get("h", 0) if state.get("moved_rendered_size") else 0
+        moved_has_size = moved_w > 200 and moved_h > 100  # rendered size after scale
+        print(f"        {state}")
+        for key in ("open", "stage_has_mermaid_div", "placeholder_exists"):
+            ok = bool(state.get(key))
+            if not ok: failures += 1
+            log(ok, key)
+        if not moved_has_size: failures += 1
+        log(moved_has_size, f"moved_rendered_size={moved_w}x{moved_h} (>200x>100)")
+
+        # Screenshot proof
+        shot = SHOTS / "lightbox-open.png"
+        page.screenshot(path=str(shot), full_page=False)
+        log(True, f"screenshot → {shot}")
+
+        print("\n=== 5. Wheel zoom transforms the moved diagram ===")
+        pre = page.evaluate(
+            "() => { var el = document.querySelector('#rb-mermaid-lightbox .rb-lb-stage div.mermaid');"
+            "        return el ? el.style.transform : null; }"
+        )
+        page.evaluate(
+            """() => {
+              const ov = document.getElementById('rb-mermaid-lightbox');
+              ov.dispatchEvent(new WheelEvent('wheel', { deltaY: -200, bubbles: true, cancelable: true }));
+            }"""
+        )
+        post = page.evaluate(
+            "() => { var el = document.querySelector('#rb-mermaid-lightbox .rb-lb-stage div.mermaid');"
+            "        return el ? el.style.transform : null; }"
+        )
+        ok = pre != post and post and "scale" in post
+        if not ok: failures += 1
+        log(ok, f"wheel transform: '{pre}' -> '{post}'")
+
+        shot2 = SHOTS / "lightbox-zoomed.png"
+        page.screenshot(path=str(shot2), full_page=False)
+        log(True, f"zoomed screenshot → {shot2}")
+
+        print("\n=== 6. Escape closes + diagram returns to article ===")
+        page.keyboard.press("Escape")
+        try:
+            page.wait_for_function(
+                """() => !document.querySelector('#rb-mermaid-lightbox.rb-lb-open') &&
+                        document.querySelector('.md-content article div.mermaid') !== null &&
+                        !document.querySelector('.rb-mermaid-placeholder')""",
+                timeout=2_000,
+            )
+            log(True, "Escape closed + diagram restored in article")
+        except Exception as e:
+            failures += 1
+            log(False, f"Escape did not restore: {e}")
+            state2 = page.evaluate(
+                """() => ({
+                  lightbox_still_open: !!document.querySelector('#rb-mermaid-lightbox.rb-lb-open'),
+                  diagram_back_in_article: !!document.querySelector('.md-content article div.mermaid'),
+                  placeholder_still_present: !!document.querySelector('.rb-mermaid-placeholder'),
+                })"""
+            )
+            print(f"        {state2}")
+
+        browser.close()
+
+    print(f"\n=== RESULT: {'PASS' if failures == 0 else 'FAIL'} ({failures} failure(s)) ===\n")
+    return 0 if failures == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(run())


### PR DESCRIPTION
## Summary

Complete documentation rewrite for the Manipulation area, plus a new in-page Mermaid lightbox.

**Six commits, ordered by concern:**

1. **`chore`** — Enable the mkdocs-material extensions the new docs depend on (admonitions, tabs, details, tasklists, emoji, superfences mermaid custom_fences). Remove the dead `polyfill.io` URL that was throwing `ERR_NAME_NOT_RESOLVED`.
2. **`docs(manipulation): rewrite area docs`** — All seven pages under `docs/development/manipulation/` (overview, setup, architecture, packages, tasks, interfaces, spotlights). Every claim was verified against `main` of `RoBorregos/home2`:
   - **overview.md** — hero, navigation cards, Mermaid pipeline diagram, hardware table, glossary.
   - **setup.md** — docker workflow, tabs for sim/real/CPU/CUDA/L4T, troubleshooting collapsibles.
   - **architecture.md** — node inventory, Mermaid sequence diagrams for pick / place / pour, endpoint constants, real tuning values (RANSAC 0.03 m, cluster 0.04 m, heatmap 0.015 m).
   - **packages.md** — every in-tree package and submodule. Service ownership corrected (`test_only_orchestrator` owns `PickPerceptionService` / `PlacePerceptionService`).
   - **tasks.md** — launch hierarchy, `./run.sh` shortcuts, `keyboard_input` menu, named-configuration table, cutlery force-guard knobs.
   - **interfaces.md** — verbatim shapes of every `.action` / `.srv` / `.msg` in `frida_interfaces/manipulation/`.
   - **spotlights.md** — unified single style across all weekly entries.
   - **Areas/Manipulation.md** — refreshed to match the current pipeline.
3. **`docs(manipulation): add 2026 advances page`** — `docs/years/2026/Manipulation/index.md` with per-area breakdown of what landed in `home2/main` during the cycle (Jan–May 2026). Every contribution links to its merged PR. Contributors table only lists members with merged PRs on main.
4. **`feat(docs): mermaid lightbox`** — Click the **⤢ Enlarge** badge on any diagram to open a full-screen lightbox with wheel-zoom and drag-pan. Works around Material's closed shadow DOM by moving the diagram into the modal (the shadow travels with it) and restoring it on close.
5. **`perf(docs): lightbox responsive on zoom/pan`** — Drop \`backdrop-filter: blur\` (compositor cost), drop the CSS transition (JS already drives at RAF rate), \`translate3d\` + \`contain: layout style paint\`, RAF-coalesce wheel writes.
6. **`fix(docs): keep diagrams crisp at rest, fast during interaction`** — Toggle \`will-change: transform\` only during wheel/drag, release after 180 ms idle so the browser re-rasterizes the SVG crisp at the final scale.

## Stats

```
15 files changed, 3345 insertions(+), 725 deletions(-)
```

## Test plan

- [x] \`mkdocs build --strict\` passes with zero warnings.
- [x] End-to-end Playwright test (\`tests/test_mermaid_lightbox.py\`) passes: 4 diagrams render, badges attached, click opens lightbox, diagram moved into stage at fit-scale, wheel transforms apply, Escape restores diagram. **PASS, 0 failures**.
- [x] Visual check: diagrams render crisp at all zoom levels; zoom + pan are smooth.

## Manual repro

\`\`\`bash
./run.sh                                            # mkdocs serve
# open http://127.0.0.1:8000/development/manipulation/architecture/
# click "⤢ Enlarge" on any diagram → lightbox opens
# wheel up = zoom in, wheel down = zoom out
# drag = pan, Esc / X / backdrop click = close
\`\`\`